### PR TITLE
Added test for interface correctness.  Corrected order of operations …

### DIFF
--- a/src/cyclus_origen_interface.cpp
+++ b/src/cyclus_origen_interface.cpp
@@ -21,7 +21,7 @@ void cyclus2origen::set_lib_path(const std::string lib_path){
   auto dr = opendir(lib_path.c_str());
   if(dr==NULL){
     std::stringstream ss;
-    ss << "Cyborg::reactor::set_lib_path(" << __LINE__ << ") : Directory provided is not a directory!" << std::endl;
+    ss << "Cyborg::reactor::set_lib_path(" << __LINE__ << ") : Directory provided is not a directory!\n";
     throw IOError(ss.str());
   }
   closedir(dr);
@@ -44,14 +44,14 @@ void cyclus2origen::remove_lib_names(const std::vector<std::string> &lib_names){
 }
 
 void cyclus2origen::list_lib_names() const{
-  for(auto lib : b_lib_names) std::cout << "Library name: " << lib << std::endl;
+  for(auto lib : b_lib_names) std::cout << "Library name: " << lib << '\n';
 }
 
 void cyclus2origen::get_lib_names(std::vector<std::string> &lib_names) const{
   using cyclus::StateError;
   if(!lib_names.empty()){
     std::stringstream ss;
-    ss << "Cyborg::reactor::get_lib_names(" << __LINE__ << ") : Return vector for lib_names not empty upon function call!" << std::endl;
+    ss << "Cyborg::reactor::get_lib_names(" << __LINE__ << ") : Return vector for lib_names not empty upon function call!\n";
     throw StateError(ss.str());
   }
   lib_names=b_lib_names;
@@ -73,12 +73,12 @@ void cyclus2origen::remove_id_tag(const std::string idname){
   using cyclus::StateError;
   if(b_tm==NULL){
     std::stringstream ss;
-    ss << "Cyborg::reactor::remove_id_tag(" << __LINE__ << ") : No tag manager found on this interface object!" << std::endl;
+    ss << "Cyborg::reactor::remove_id_tag(" << __LINE__ << ") : No tag manager found on this interface object!\n";
     throw StateError(ss.str());
   }
   if(!b_tm->hasTag(idname)){
     std::stringstream ss;
-    ss << "Cyborg::reactor::remove_id_tag(" << __LINE__ << ") : Tag manager does not have a tag with name = " << idname << "!" << std::endl;
+    ss << "Cyborg::reactor::remove_id_tag(" << __LINE__ << ") : Tag manager does not have a tag with name = " << idname << "!\n";
     throw StateError(ss.str());
   }
   b_tm->deleteTag(idname);
@@ -88,16 +88,16 @@ void cyclus2origen::list_id_tags() const{
   using cyclus::StateError;
   if(b_tm==NULL){
     std::stringstream ss;
-    ss << "Cyborg::reactor::list_id_tags(" << __LINE__ << ") : No tag manager found on this interface object!" << std::endl;
+    ss << "Cyborg::reactor::list_id_tags(" << __LINE__ << ") : No tag manager found on this interface object!\n";
     throw StateError(ss.str());
   }
   if(b_tm->listIdTags().size()==0){
     std::stringstream ss;
-    ss << "Cyborg::reactor::list_id_tags(" << __LINE__ << ") : No ID tags found on this interface object!  Use set_id_tags()." << std::endl;
+    ss << "Cyborg::reactor::list_id_tags(" << __LINE__ << ") : No ID tags found on this interface object!  Use set_id_tags().\n";
     throw StateError(ss.str());
   }
   for(auto tags : b_tm->listIdTags()){
-    std::cout << "Tag name: " << tags << ", value: " << b_tm->getIdTag(tags) << "." << std::endl;
+    std::cout << "Tag name: " << tags << ", value: " << b_tm->getIdTag(tags) << ".\n";
   }
 }
 
@@ -105,17 +105,17 @@ void cyclus2origen::get_id_tags(std::vector<std::string> &names, std::vector<std
   using cyclus::StateError;
   if(b_tm==NULL){
     std::stringstream ss;
-    ss << "Cyborg::reactor::get_id_tags(" << __LINE__ << ") : No tag manager found on this interface object!" << std::endl;
+    ss << "Cyborg::reactor::get_id_tags(" << __LINE__ << ") : No tag manager found on this interface object!\n";
     throw StateError(ss.str());
   }
   if(!names.empty()){
     std::stringstream ss;
-    ss << "Cyborg::reactor::get_id_tags(" << __LINE__ << ") : Return vector for ID tag names not emtpy upon function call!" << std::endl;
+    ss << "Cyborg::reactor::get_id_tags(" << __LINE__ << ") : Return vector for ID tag names not emtpy upon function call!\n";
     throw StateError(ss.str());
   }
   if(!values.empty()){
     std::stringstream ss;
-    ss << "Cyborg::reactor::get_id_tags(" << __LINE__ << ") : Return vector for ID tag values not empty upon function call!" << std::endl;
+    ss << "Cyborg::reactor::get_id_tags(" << __LINE__ << ") : Return vector for ID tag values not empty upon function call!\n";
     throw StateError(ss.str());
   }
   for(auto tag : b_tm->listIdTags()){
@@ -129,27 +129,27 @@ void cyclus2origen::set_materials(const std::vector<int> &ids, const std::vector
   using cyclus::ValueError;
   if(b_lib==NULL){
     std::stringstream ss;
-    ss << "Cyborg::reactor::set_materials(" << __LINE__ << ") : No library found on this interface object!  Use interpolate() first." << std::endl;
+    ss << "Cyborg::reactor::set_materials(" << __LINE__ << ") : No library found on this interface object!  Use interpolate() first.\n";
     throw StateError(ss.str());
   }
   if(b_vol<=0){
     std::stringstream ss;
-    ss << "Cyborg::reactor::set_materials(" << __LINE__ << ") : Volume should be implicitly set...." << std::endl;
+    ss << "Cyborg::reactor::set_materials(" << __LINE__ << ") : Volume should be implicitly set....\n";
     throw ValueError(ss.str());
   }
   if(ids.size()==0){
     std::stringstream ss;
-    ss << "Cyborg::reactor::set_materials(" << __LINE__ << ") : No IDs provided in ID vector!" << std::endl;
+    ss << "Cyborg::reactor::set_materials(" << __LINE__ << ") : No IDs provided in ID vector!\n";
     throw StateError(ss.str());
   }
   if(concs.size()==0){
     std::stringstream ss;
-    ss << "Cyborg::reactor::set_materials(" << __LINE__ << ") : No concentrations were provided in the concentrations vector!" << std::endl;
+    ss << "Cyborg::reactor::set_materials(" << __LINE__ << ") : No concentrations were provided in the concentrations vector!\n";
     throw StateError(ss.str());
   }
   if(concs.size()!=ids.size()){
     std::stringstream ss;
-    ss << "Cyborg::reactor::set_materials(" << __LINE__ << ") : Size mismatch between ID and concentrations vectors!" << std::endl;
+    ss << "Cyborg::reactor::set_materials(" << __LINE__ << ") : Size mismatch between ID and concentrations vectors!\n";
     throw ValueError(ss.str());
   }
   std::string name = "cyclus_";
@@ -160,33 +160,41 @@ void cyclus2origen::set_materials(const std::vector<int> &ids, const std::vector
   std::vector<int> tmp_ids;
   tmp_ids.assign(ids.begin(),ids.end());
 
+  //  Looping through IDs provided to ensure it is valid and translate to pizzzaaa as necessary.
   for( auto &zaid : tmp_ids ) {     
      if(ScaleData::Utils::is_valid_pizzzaaa(zaid)) continue;    
 
      if(ScaleData::Utils::is_valid_zzzaaai(zaid)) zaid = ScaleData::Utils::zzzaaai_to_pizzzaaa(zaid);
      if(!ScaleData::Utils::is_valid_pizzzaaa(zaid)){
         std::stringstream ss;
-        ss << "Cyborg::reactor::set_materials(" << __LINE__ << ") : Unrecognizeable nuclide ID name! Use zzzaaai or pizzzaaa format." << std::endl;
+        ss << "Cyborg::reactor::set_materials(" << __LINE__ << ") : Unrecognizeable nuclide ID name! Use zzzaaai or pizzzaaa format.\n";
         throw ValueError(ss.str());
      }
   }
 
   // Group together nuclide IDs and masses under a concentrations object to handle unit conversions
   // Replace any prior concentrations (if initialized)
+  // Units should be set before concentration values are set.
   b_nucset = std::make_shared<Origen::NuclideSet>(tmp_ids);
-  b_concs = std::make_shared<Origen::Concentrations>(b_concUnits);
+  b_concs = std::make_shared<Origen::Concentrations>();
 
-  //b_nucset.set_ids(tmp_ids);
   b_concs->set_nuclide_set(*b_nucset);
-  b_concs->set_vals(concs);
+  b_concs->set_units(b_concUnits);  // Units first. Setting in constructor potentially wonky.
+  b_concs->set_vals(concs);         // Then values.
 
-  int id = 1001;
+  int id = 1001; // Arbitrary.
   Origen::SP_Material mat = Origen::SP_Material(new Origen::Material(b_lib,name,id,b_vol));
-  //mat->set_numden_bos(tmp_concs,tmp_ids,b_vol);
   mat->set_concs_at(*b_concs,0);
-  std::cerr << "Material::initial_mass() = " << mat->initial_mass() << std::endl;
-  std::cerr << "Material::initial_hm_mass() = " << mat->initial_hm_mass() << std::endl;
-  b_mat = mat;
+
+//  std::cerr << "Material::initial_mass() = " << mat->initial_mass() << " grams.\n";
+//  std::cerr << "Material::initial_hm_mass() = " << mat->initial_hm_mass() << " grams.\n";
+
+  b_mat = mat; // Used in prob_spec_lib function.
+  prob_spec_lib(b_lib,b_times,b_fluxes,b_powers); // Takes b_lib and interpolates to new burnups based on b_times and b_powers.
+  auto mat2 = std::make_shared<Origen::Material>(b_lib,name,id,b_vol); // Generates new material based on b_lib from prob_spec_lib
+  mat2->set_concs_at(*b_concs,0); // Concentrations are the same regardless.
+  b_mat->clear();
+  b_mat = mat2;
 }
 
 void cyclus2origen::reset_material(){
@@ -205,18 +213,11 @@ void cyclus2origen::set_power_units(const char* power_units){
   b_powerUnits = Origen::Power::units(power_units);
 }
 
-/*
-   std::transform(b_times.begin(), b_times.end(), b_times.begin(),
-      std::bind1st(std::multiplies<double>(){ 
-         Origen::Time::factor<Origen::Time::SECONDS>(this->b_timeUnits));
-      } ));
-*/
-
 void cyclus2origen::add_time_step(const double time){
    using cyclus::StateError;
    if(time<0){
       std::stringstream ss;
-      ss << "Cyborg::reactor::add_time_step(" << __LINE__ << ") : Time value provided is non-physical (<0)!" << std::endl;
+      ss << "Cyborg::reactor::add_time_step(" << __LINE__ << ") : Time value provided is non-physical (i.e. - less than zero)!\n";
       throw StateError(ss.str());
    }
    b_times.push_back(time);
@@ -226,7 +227,7 @@ void cyclus2origen::set_fluxes(const std::vector<double> &fluxes){
   using cyclus::StateError;
   if(fluxes.size()==0){
     std::stringstream ss;
-    ss << "Cyborg::reactor::set_flux(" << __LINE__ << ") : Vector of fluxes provided is empty!" << std::endl;
+    ss << "Cyborg::reactor::set_flux(" << __LINE__ << ") : Vector of fluxes provided is empty!\n";
     throw StateError(ss.str());
   }
   b_fluxes = fluxes;
@@ -236,7 +237,7 @@ void cyclus2origen::add_flux(const double flux){
   using cyclus::StateError;
   if(flux<0){
     std::stringstream ss;
-    ss << "Cyborg::reactor::add_flux(" << __LINE__ << ") : Flux value provided is non-physical (<0)!" << std::endl;
+    ss << "Cyborg::reactor::add_flux(" << __LINE__ << ") : Flux value provided is non-physical (<0)!\n";
     throw StateError(ss.str());
   }
   b_fluxes.push_back(flux);
@@ -250,7 +251,7 @@ void cyclus2origen::set_powers(const std::vector<double> &powers){
   using cyclus::StateError;
   if(powers.size()==0){
     std::stringstream ss;
-    ss << "Cyborg::reactor::set_powers(" << __LINE__ << ") : Vector of powers provided is empty!" << std::endl;
+    ss << "Cyborg::reactor::set_powers(" << __LINE__ << ") : Vector of powers provided is empty!\n";
     throw StateError(ss.str());
   }
   b_powers = powers;
@@ -260,7 +261,7 @@ void cyclus2origen::add_power(const double power){
   using cyclus::StateError;
   if(power<0){
     std::stringstream ss;
-    ss << "Cyborg::reactor::add_power(" << __LINE__ << ") : Power provided is non-physical (<0)!" << std::endl;
+    ss << "Cyborg::reactor::add_power(" << __LINE__ << ") : Power provided is non-physical (<0)!\n";
     throw StateError(ss.str());
   }
   b_powers.push_back(power);
@@ -286,12 +287,12 @@ void cyclus2origen::remove_parameter(const std::string name){
   using cyclus::StateError;
   if(b_tm==NULL){
     std::stringstream ss;
-    ss << "Cyborg::reactor::remove_parameter(" << __LINE__ << ") : No tag manager found on this interface object!" << std::endl;
+    ss << "Cyborg::reactor::remove_parameter(" << __LINE__ << ") : No tag manager found on this interface object!\n";
     throw StateError(ss.str());
   }
   if(!b_tm->hasTag(name)){
     std::stringstream ss;
-    ss << "Cyborg::reactor::remove_parameter(" << __LINE__ << ") : No tag with name " << name << " found on this interface object!" << std::endl;
+    ss << "Cyborg::reactor::remove_parameter(" << __LINE__ << ") : No tag with name " << name << " found on this interface object!\n";
     throw StateError(ss.str());
   }
 
@@ -302,16 +303,16 @@ void cyclus2origen::list_parameters() const{
   using cyclus::StateError;
   if(b_tm==NULL){
     std::stringstream ss;
-    ss << "Cyborg::reactor::list_parameters(" << __LINE__ << ") : No tag manager found on this interface object!" << std::endl;
+    ss << "Cyborg::reactor::list_parameters(" << __LINE__ << ") : No tag manager found on this interface object!\n";
     throw StateError(ss.str());
   }
   if(b_tm->listInterpTags().size()==0){
     std::stringstream ss;
-    ss << "Cyborg::reactor::list_parameters(" << __LINE__ << ") : No parameters found on this tag manager!" << std::endl;
+    ss << "Cyborg::reactor::list_parameters(" << __LINE__ << ") : No parameters found on this tag manager!\n";
     throw StateError(ss.str());
   }
   for(auto tag : b_tm->listInterpTags()){
-    std::cout << "Interp tag name: " << tag << ", value: " << b_tm->getInterpTag(tag) << "." << std::endl;
+    std::cout << "Interp tag name: " << tag << ", value: " << b_tm->getInterpTag(tag) << ".\n";
   }
 }
 
@@ -319,17 +320,17 @@ void cyclus2origen::get_parameters(std::vector<std::string> &names, std::vector<
   using cyclus::StateError;
   if(!names.empty()){
     std::stringstream ss;
-    ss << "Cyborg::reactor::get_parameters(" << __LINE__ << ") : Return vector for names not empty upon function call!" << std::endl;
+    ss << "Cyborg::reactor::get_parameters(" << __LINE__ << ") : Return vector for names not empty upon function call!\n";
     throw StateError(ss.str());
   }
   if(!values.empty()){
     std::stringstream ss;
-    ss << "Cyborg::reactor::get_parameters(" << __LINE__ << ") : Return vector for values not empty upon function call!" << std::endl;
+    ss << "Cyborg::reactor::get_parameters(" << __LINE__ << ") : Return vector for values not empty upon function call!\n";
     throw StateError(ss.str());
   }
   if(b_tm==NULL){
     std::stringstream ss;
-    ss << "Cyborg::reactor::get_parameters(" << __LINE__ << ") : No tag manager present with parameters!" << std::endl;
+    ss << "Cyborg::reactor::get_parameters(" << __LINE__ << ") : No tag manager present with parameters!\n";
     throw StateError(ss.str());
   }
   for(auto tag : b_tm->listInterpTags()){
@@ -338,36 +339,24 @@ void cyclus2origen::get_parameters(std::vector<std::string> &names, std::vector<
   }
 }
 
-//void set_solver(const int svlr=0){
-//  Defaulting to CRAM.  Should be this easy to swap in
-//  matrex if desired, but not including it for now.
-//
-//  if(slvr==1){
-//    b_slv=Origen::Solver_matrex();
-//  } else {
-//    b_slv=Origen::Solver_cram();
-//  }
-//}
-
 void cyclus2origen::interpolate() {
   using cyclus::ValueError;
   using cyclus::StateError;
   if(b_tm==NULL){
     std::stringstream ss;
-    ss << "Cyborg::reactor::interpolate(" << __LINE__ << ") : No tag manager found!" << std::endl;
+    ss << "Cyborg::reactor::interpolate(" << __LINE__ << ") : No tag manager found!\n";
     throw StateError(ss.str());
   }
   if(b_tm->listIdTags().size()==0){
     std::stringstream ss;
-    ss << "Cyborg::reactor::interpolate(" << __LINE__ << ") : No ID tags found!" << std::endl;
+    ss << "Cyborg::reactor::interpolate(" << __LINE__ << ") : No ID tags found!\n";
     throw StateError(ss.str());
   }
   if(b_lib_names.size()==0 && b_lib_path.size()==0){
     std::stringstream ss;
-    ss << "Cyborg::reactor::interpolate(" << __LINE__ << ") : No library names or path specified!" << std::endl;
+    ss << "Cyborg::reactor::interpolate(" << __LINE__ << ") : No library names or path specified!\n";
     throw cyclus::ValueError(ss.str());
   }
-
   if(b_lib_names.size()==0){
     struct dirent *drnt;
     auto dr = opendir(b_lib_path.c_str());
@@ -381,7 +370,7 @@ void cyclus2origen::interpolate() {
       lib_name = b_lib_path + midstring + lib_name;
       struct stat buffer;
       if(stat(lib_name.c_str(), &buffer) != 0){
-        std::cout << lib_name << " doesn't exist!" << std::endl;
+        std::cout << lib_name << " doesn't exist!\n";
       }else{
         b_lib_names.push_back(lib_name);
       }
@@ -389,21 +378,23 @@ void cyclus2origen::interpolate() {
     closedir(dr);
   }
 
+    
+
   // Bail if no libraries specified
   if(b_lib_names.size() == 0) {
     std::stringstream ss;
-    ss << "Cyborg::reactor::interpolate(" << __LINE__ << ") : No libraries specified or found!" << std::endl;
+    ss << "Cyborg::reactor::interpolate(" << __LINE__ << ") : No libraries specified or found!\n";
     throw ValueError(ss.str());
   }
 
-  std::vector<Origen::SP_TagManager> tms = Origen::collectLibraries(b_lib_names);
+  std::vector<Origen::SP_TagManager> tms = Origen::collectLibrariesParallel(b_lib_names);
   std::vector<Origen::TagManager> tagman;
   for(auto& tm : tms) tagman.push_back(*tm);
 
   // Bail if no libraries found
   if(tagman.size() == 0) {
     std::stringstream ss;
-    ss << "Cyborg::reactor::interpolate(" << __LINE__ << ") : No libraries found that have tag managers!" << std::endl;
+    ss << "Cyborg::reactor::interpolate(" << __LINE__ << ") : No libraries found that have tag managers!\n";
     throw ValueError(ss.str());
   }
 
@@ -411,7 +402,7 @@ void cyclus2origen::interpolate() {
   tagman = Origen::selectLibraries(tagman,*b_tm);
   if(tagman.size() == 0){
     std::stringstream ss;
-    ss << "Cyborg::reactor::interpolate(" << __LINE__ << ") : No libraries found that match specified ID tags!" << std::endl;
+    ss << "Cyborg::reactor::interpolate(" << __LINE__ << ") : No libraries found that match specified ID tags!\n";
     throw ValueError(ss.str());
   }
 
@@ -425,7 +416,7 @@ void cyclus2origen::solve() {
    
    if(b_powers.size()==0 && b_fluxes.size()==0) {
       std::stringstream ss;
-      ss << "Cyborg::reactor::solve(" << __LINE__ << ") : No powers or fluxes found on this interface object!  Use set_fluxes or set_powers." << std::endl;
+      ss << "Cyborg::reactor::solve(" << __LINE__ << ") : No powers or fluxes found on this interface object!  Use set_fluxes or set_powers.\n";
       throw StateError(ss.str());
    }
 
@@ -437,33 +428,32 @@ void cyclus2origen::solve(std::vector<double>& times, std::vector<double>& fluxe
    using cyclus::ValueError;
    if(b_mat==NULL){
       std::stringstream ss;
-      ss << "Cyborg::reactor::solve(" << __LINE__ << ") : No material object found on this interface object!  Use set_materials() or set_materials_with_masses()." << std::endl;
+      ss << "Cyborg::reactor::solve(" << __LINE__ << ") : No material object found on this interface object!  Use set_materials() or set_materials_with_masses().\n";
       throw StateError(ss.str());
    }
    if(b_mat->library()==NULL) {
       std::stringstream ss;
-      ss << "Cyborg::reactor::solve(" << __LINE__ << ") : No library object found on the material object on this interface object.!" << std::endl;
+      ss << "Cyborg::reactor::solve(" << __LINE__ << ") : No library object found on the material object on this interface object!\n";
       throw StateError(ss.str());
    }
    if(powers.size()==0 && fluxes.size()==0){
       std::stringstream ss;
-      ss << "Cyborg::reactor::solve(" << __LINE__ << ") : No powers or fluxes specified for depletion!" << std::endl;
+      ss << "Cyborg::reactor::solve(" << __LINE__ << ") : No powers or fluxes specified for depletion!\n";
       throw StateError(ss.str());
    }
    if(powers.size()!=(times.size()-1) && powers.size()!=0){
       std::stringstream ss;
-      ss << "Cyborg::reactor::solve(" << __LINE__ << ") : Powers vector must be exactly 1 element shorter than times vector!" << std::endl \
-         << "Power vector size is " << powers.size() << " and times vector size is " << times.size() << "." << std::endl;
+      ss << "Cyborg::reactor::solve(" << __LINE__ << ") : Powers vector must be exactly 1 element shorter than times vector!\n" \
+         << "Power vector size is " << powers.size() << " and times vector size is " << times.size() << ".\n";
       throw ValueError(ss.str());
    }
-   if(fluxes.size()!=(times.size()-1) && fluxes.size()!=0){
+
+   if(b_mat->amount_at(0)->size() == 0){
       std::stringstream ss;
-      ss << "Cyborg::reactor::solve(" << __LINE__ << ") : Fluxes vector must be exactly 1 element shorter than times vector!" << std::endl \
-         << "Fluxes vector size is " << fluxes.size() << " and times vector size is " << times.size() << "." << std::endl;
-      throw ValueError(ss.str());
+      ss << "Cyborg::reactor::solve(" << __LINE__ << ") : Materials object has no material masses set.  Run set_materials first.\n";
+      throw StateError(ss.str());
    }
-   // TODO: Should probably check that we have initialized concentrations on the material object as well...
-  
+
    // Initialize the solver
    Origen::SP_Solver solver;
    ScaleUtils::IO::DB db;
@@ -471,10 +461,8 @@ void cyclus2origen::solve(std::vector<double>& times, std::vector<double>& fluxe
    solver = Origen::SolverSelector::get_solver(db);
    b_mat->set_solver(solver);
  
-   prob_spec_lib(b_lib,times,fluxes,powers);
    size_t num_steps = powers.size()>fluxes.size() ? powers.size() : fluxes.size();
    std::vector<double> dt_rel(2, 0.5);
-  
    for(size_t i = 0; i < num_steps; i++){
     
      b_mat->add_step((times[i+1]-times[i])*Origen::Time::factor<Origen::Time::SECONDS>(this->b_timeUnits));
@@ -505,25 +493,96 @@ void cyclus2origen::get_masses_at(int p, std::vector<double> &masses_out, const 
 
    if( p < 0 || p >= b_mat->ntimes() ){
      std::stringstream ss;
-     ss << "Cyborg::reactor::get_concentrations_at(" << __LINE__ << ") : Step requested " << p << " falls outside the bounds [0," << b_mat->ntimes() << "]!" << std::endl;
+     ss << "Cyborg::reactor::get_masses_at(" << __LINE__ << ") : Step requested " << p << " falls outside the bounds [0," << b_mat->ntimes() << "]!\n";
      throw ValueError(ss.str());
    }
 
    Origen::ConcentrationUnit concUnits = Origen::convertStringToConcUnit(units);
 
    Origen::SP_NuclideSet tmpNucSet = std::make_shared<Origen::NuclideSet>(*(b_mat->sizzzaaa_list()));
-   Origen::SP_Concentrations tmpConcs = std::make_shared<Origen::Concentrations>(concUnits);
+   Origen::SP_Concentrations tmpConcs = std::make_shared<Origen::Concentrations>(); // Get values off of materials object, then set_units to desired units.
+   tmpConcs->set_nuclide_set(*tmpNucSet);
+
+   masses_out.clear();
+   b_mat->get_concs_at(tmpConcs.get(), p);                    // Get values.
+   tmpConcs->set_units(Origen::ConcentrationUnit::KILOGRAMS); // Set units.
+ 
+   tmpConcs->get_vals(masses_out); 
+}
+
+void cyclus2origen::get_masses_at_easy(int p, std::map<int,double> &masses_out, const std::string id_type, const std::string units) const{
+   using cyclus::ValueError;
+
+   if( p < 0 || p >= b_mat->ntimes() ){
+       std::stringstream ss;
+       ss << "Cyborg::reactor::get_masses_at_easy(" << __LINE__ << "): Step requested " << p << " falls outside the bounds [0," << b_mat->ntimes() << "]!\n";
+       throw ValueError(ss.str());
+   }
+
+   Origen::SP_NuclideSet tmpNucSet = std::make_shared<Origen::NuclideSet>(*(b_mat->sizzzaaa_list()));
+   Origen::SP_Concentrations tmpConcs = std::make_shared<Origen::Concentrations>();
    tmpConcs->set_nuclide_set(*tmpNucSet);
 
    masses_out.clear();
    b_mat->get_concs_at(tmpConcs.get(), p);
- 
-   tmpConcs->get_vals(masses_out); 
-   tmpConcs->set_units(concUnits);   
+   tmpConcs->set_units(Origen::convertStringToConcUnit(units));
+
+   std::vector<int> ids;
+   std::vector<double> tmp_out;
+
+   tmpConcs->get_vals(tmp_out);
+   
+   if(id_type == "sizzzaaa"){
+      this->get_ids(ids);
+   }else if(id_type == "zzzaaai"){
+       this->get_ids_zzzaaai(ids);
+   }else{
+       std::stringstream ss;
+       ss << "Cyborg::reactor::get_masses_at_easy(" << __LINE__ << ") : Type of nuclide ids requested is not recognized.  Must be 'sizzzaaa' or 'zzzaaai'.\n";
+       throw ValueError(ss.str());
+   }
+
+   if(ids.size() != tmp_out.size())
+   {
+       std::stringstream ss;
+       ss << "Cyborg::reactor::get_masses_at_easy(" << __LINE__ << ") : Number of nuclide ids (" << ids.size() << ") does not match the number of concentrations (" << tmp_out.size() << ").\n";
+       throw ValueError(ss.str());
+   }
+
+   for(size_t i = 0; i < ids.size(); i++) masses_out[ids[i]] = tmp_out[i];
 }
 
 void cyclus2origen::get_masses_final(std::vector<double> &masses_out, const std::string units) const{
   this->get_masses_at(b_mat->nsteps(), masses_out, units);
+}
+
+void cyclus2origen::get_masses_final_easy(std::map<int,double> &masses_out, const std::string id_type, const std::string units) const
+{
+   using cyclus::ValueError;
+
+   std::vector<int> ids;
+   std::vector<double> concs;
+   
+   if(id_type == "sizzzaaa"){
+      this->get_ids(ids);
+   }else if(id_type == "zzzaaai"){
+       this->get_ids_zzzaaai(ids);
+   }else{
+       std::stringstream ss;
+       ss << "Cyborg::reactor::get_masses_final_easy(" << __LINE__ << ") : Type of nuclide ids requested is not recognized.  Must be 'sizzzaaa' or 'zzzaaai'.\n";
+       throw ValueError(ss.str());
+   }
+
+   this->get_masses_final(concs, units);
+
+   if(ids.size() != concs.size())
+   {
+       std::stringstream ss;
+       ss << "Cyborg::reactor::get_masses_final_easy(" << __LINE__ << ") : Number of nuclide ids (" << ids.size() << ") does not match the number of concentrations (" << concs.size() << ").\n";
+       throw ValueError(ss.str());
+   }
+
+   for(size_t i = 0; i < ids.size(); i++) masses_out[ids[i]] = concs[i];
 }
 
 void cyclus2origen::get_ids(std::vector<int> &ids_out) const{
@@ -541,20 +600,20 @@ double cyclus2origen::burnup_last() const {
     
    if(b_mat->nsteps() == 0) {
      std::stringstream ss;
-     ss << "Cyborg::reactor::get_burnup_final(" << __LINE__ << ") : No burnup steps found!" << std::endl;
+     ss << "Cyborg::reactor::get_burnup_final(" << __LINE__ << ") : No burnup steps found!\n";
      throw StateError(ss.str());
      return -1.0;
    }
-   return this->burnup_at(b_mat->nsteps());
+   return this->burnup_at(b_mat->nsteps()-1);
 }
 
 double cyclus2origen::burnup_at(const int stepNum) const {
    using cyclus::ValueError;
 
-   if(stepNum < 0 || stepNum > b_mat->nsteps()) {
+   if(stepNum < 0 || stepNum >= b_mat->nsteps()) {
       std::stringstream ss;
       ss << "Cyborg::reactor::burnup_at(" << __LINE__ << ") : Step requested " 
-         << stepNum << " falls outside the bounds [0," << b_mat->nsteps() << "]!" << std::endl;
+         << stepNum << " falls outside the bounds [0," << b_mat->nsteps()-1 << "]!\n";
       throw ValueError(ss.str());
       return -1.0;
    }
@@ -574,7 +633,7 @@ void cyclus2origen::prob_spec_lib(Origen::SP_Library lib, const std::vector<doub
       for(auto& flux : fluxes) powTmp.push_back(flux*b_mat->power_factor_bos());
    } else if(!(fluxes.empty() || powers.empty()) ) {
       std::stringstream ss;
-      ss << "Cyborg::reactor::prob_spec_lib(" << __LINE__ << ") : Both the fluxes and powers vectors have values! Choose one!" << std::endl;
+      ss << "Cyborg::reactor::prob_spec_lib(" << __LINE__ << ") : Both the fluxes and powers vectors have values! Choose one!\n";
       throw cyclus::ValueError(ss.str());
    }
    else {
@@ -583,8 +642,8 @@ void cyclus2origen::prob_spec_lib(Origen::SP_Library lib, const std::vector<doub
 
    if(times.size()!=powers.size()+1){
       std::stringstream ss;
-      ss << "Cyborg::reactor::prob_spec_lib(" << __LINE__ << ") : Powers or fluxes vectors not exactly 1 element shorter than times vector!" << std::endl \
-         << "Powers or fluxes vector has " << powers.size() << " elements and times vector has " << times.size() << " elements." << std::endl;
+      ss << "Cyborg::reactor::prob_spec_lib(" << __LINE__ << ") : Powers or fluxes vectors not exactly 1 element shorter than times vector!\n" \
+         << "Powers or fluxes vector has " << powers.size() << " elements and times vector has " << times.size() << " elements.\n";
       throw cyclus::ValueError(ss.str());
    }
 
@@ -595,16 +654,13 @@ void cyclus2origen::prob_spec_lib(Origen::SP_Library lib, const std::vector<doub
       buTmp = powTmp[i]*(timeTmp[i+1]-timeTmp[i])/b_mat->initial_hm_mass();
       if(i > 0) buTmp += burnups.back();
       burnups.push_back(buTmp);
-      std::stringstream ss;
-      ss << "Cyborg::reactor::prob_spec_lib(" << __LINE__ << ") : Burnups(" << i << ") = " << burnups[i] << std::endl;
    }
    if(burnups.size()!=powers.size()){
       std::stringstream ss;
-      ss << "Cyborg::reactor::prob_spec_lib(" << __LINE__ << ") : Calculated burnup vector does not have same size as provided powers vector!" << std::endl;
+      ss << "Cyborg::reactor::prob_spec_lib(" << __LINE__ << ") : Calculated burnup vector does not have same size as provided powers vector!\n";
       throw cyclus::StateError(ss.str());
    }
-
-   b_lib = lib->interpolate_Interp1D(burnups);
+  b_lib = lib->interpolate_Interp1D(burnups);
 }
 
 }//namespace

--- a/src/cyclus_origen_interface.h
+++ b/src/cyclus_origen_interface.h
@@ -7,9 +7,8 @@
 #include "Origen/Core/dc/Library.h"
 #include "Origen/Core/dc/Material.h"
 #include "Origen/Core/dc/Power.h"
+#include "Origen/Core/dc/TagManager.h"
 #include "Origen/Core/dc/Time.h"
-//#include "Origen/Core/xf/Solver.h"
-//#include "Origen/Solver/cram/Solver_cram.h"
 #include "Origen/Solver/SolverSelector.h"
 
 /*!
@@ -25,8 +24,8 @@
  * \note - Envisioned usage is:
  *         set_lib_name->set_id_tag(somewhat optional)->
  *         add_parameter(optional)->interpolate->
- *         set_materials->set_flux->set_time_steps->
- *         set_**_units(as necessary)->
+ *         set_power->set_time_steps->
+ *         set_**_units(as necessary)->set_materials->
  *         set_solver(if made available)->solve.
  *         
  *         After that, concentrations at various
@@ -37,7 +36,7 @@
  *         set_lib_path->set_id_tag->add_parameter->interpolate
  *           --Gets you a problem specific library at default burnups.
  *
- *         set_materials_with_masses->solve(times,fluxes)->
+ *         set_materials_with_masses->solve(times,powers)->
  *         get_ids->get_masses.
  *           --Gets you material concentrations at specified burnups.
  *           --After initial solve, materials can be set based on output
@@ -125,28 +124,6 @@ public:
      ** \param  Empty vector of strings to be populated with ID tag values.
      */
     void get_id_tags(std::vector<std::string>&, std::vector<std::string>&) const;
-
-    /*!
-    ** \brief  Function to set the initial materials to be depleted.
-    **         Mass units conversion is automatically handled via ORIGEN;
-    **         mass units assumed to be those specified via set_mass_units
-    ** \param  Vector of ids.  Works with ids formatted in either
-    **         zzzaaai or pizzzaaa.
-    ** \param  Vector of concentrations.  Should directly correspond
-    **         to the vector of ids.
-    */
-    void set_materials(const std::vector<int>&, const std::vector<double>&);
-
-    /*!
-    ** \brief  Function to reset the material object to be replaced.
-    */
-    void reset_material();
-
-    /*!
-     ** \brief  Function to set the units used in the concentrations vectors.
-     ** \param  String declaring the units used for the materials concentrations.
-     */
-    void set_mat_units(const std::string);
 
     /*!
      ** \brief  Function to set the times at which a burn step will end,
@@ -283,6 +260,28 @@ public:
     void interpolate();
 
     /*!
+    ** \brief  Function to set the initial materials to be depleted.
+    **         Mass units conversion is automatically handled via ORIGEN;
+    **         mass units assumed to be those specified via set_mass_units
+    ** \param  Vector of ids.  Works with ids formatted in either
+    **         zzzaaai or pizzzaaa.
+    ** \param  Vector of concentrations.  Should directly correspond
+    **         to the vector of ids.
+    */
+    void set_materials(const std::vector<int>&, const std::vector<double>&);
+
+    /*!
+    ** \brief  Function to reset the material object to be replaced.
+    */
+    void reset_material();
+
+    /*!
+     ** \brief  Function to set the units used in the concentrations vectors.
+     ** \param  String declaring the units used for the materials concentrations.
+     */
+    void set_mat_units(const std::string);
+
+    /*!
      ** \brief  Function to call the solver.  Assumes time and
      **         flux/power vectors have been populated by their
      **         respective functions.
@@ -328,6 +327,8 @@ public:
      */
     void get_masses_at(int, std::vector<double>&, const std::string="kilograms") const;
 
+    void get_masses_at_easy(int, std::map<int,double>&, const std::string="zzzaaai", const std::string="kilograms") const;
+
     /*!
      ** \brief  Function to retrieve the concentrations at the end
      **         of the final burn step.
@@ -337,9 +338,18 @@ public:
     void get_masses_final(std::vector<double>&, const std::string="kilograms") const;
 
     /*!
+     ** \brief  Function to retrieve the concentrations at the end
+     **         of the final burn step in a more accessible
+     **         container.
+     ** \param  std::map to be filled with ids for keys and final
+     **         masses for values.
+     */
+    void get_masses_final_easy(std::map<int,double>&, const std::string="zzzaaai", const std::string="kilograms") const;
+
+    /*!
      ** \brief  Function to return the IDs that correspond to the
      **         concentrations fetched by the previous functions.
-     ** \param  Vector of vectors to be filled with final ids,
+     ** \param  Vector of integers to be filled with final ids,
      **         which are applicable to every burn step. Given in
      **         pizzzaaa format.
      */
@@ -388,11 +398,10 @@ protected:
     Origen::SP_Material b_mat;
     Origen::SP_NuclideSet b_nucset;
     Origen::SP_Concentrations b_concs;
-//    Solver_cram b_slv;
     std::vector<std::string> b_lib_names;
     std::string b_lib_path;
     std::string b_interp_name;
-    const double b_vol=1.;   
+    const double b_vol=1.; // cm^3  
     std::vector<double> b_burnups;
     std::vector<double> b_fluxes;
     std::vector<double> b_powers;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,7 +31,7 @@
 ###############################################################################
 
   # Add source for OrigenInterface tests
-  FILE(GLOB OrigenInterface_TEST_CC "${CMAKE_CURRENT_SOURCE_DIR}/*origen*.cpp")
+  FILE(GLOB OrigenInterface_TEST_CC "${CMAKE_CURRENT_SOURCE_DIR}/*interface*.cpp")
    
   # Build cyborg_unit_tests
   ADD_EXECUTABLE(OrigenInterface_unit_tests

--- a/tests/origen06.mod.1.out
+++ b/tests/origen06.mod.1.out
@@ -1,0 +1,1690 @@
+ *******************************************************************************
+ *                                                                             *
+ *                               SCALE 6.3.beta1                               *
+ *                                -------------                                *
+ *                                  July 2016                                  *
+ *                                                                             *
+ *           SCALE:  A Comprehensive Modeling and Simulation Suite             *
+ *                   for Nuclear Safety Analysis and Design                    *
+ *                                                                             *
+ *                      Reactor and Nuclear Systems Division                   *
+ *                        Oak Ridge National Laboratory                        *
+ *                                                                             *
+ *                           http://scale.ornl.gov                             *
+ *                            scalehelp@ornl.gov                               *
+ *                                                                             *
+ *******************************************************************************
+ *******************************************************************************
+      
+                  Job Information
+                  ---------------
+      Job started on necluster on Wed 13/07/2016 18:08:13
+      Working directory: /tmp/scale.nsly.28828
+      Input file name  : /home/nsly/cyclus/cyborg/tests/origen06.mod.1.inp
+      Output file name : /home/nsly/cyclus/cyborg/tests/origen06.mod.1.out
+      SCALE executable : /home/nsly/scale.dev/build/noGtest/INSTALL/bin/scale
+      
+ *******************************************************************************
+The following data cards precede an = card
+      'CTESTLABEL: {<TestOrigen>}
+      '#TestGrep# -i "erro[r]" ${OUTPUTFILENAME} | ${GREP} -v "[W]arnings and [E]rrors"
+      '#TestGrep# "ORIGEN finished successfull[y]" ${OUTPUTFILENAME}
+      '#TestGrep# -A20 "Element concentrations in gram-atom[s]" ${OUTPUTFILENAME} | ${GREP} "totals" | ${AWK} "{print $10}"
+      '#TestGrep# -A60 "Element concentrations in gram[s]" ${OUTPUTFILENAME} | ${GREP} "totals" | ${AWK} "{print $10}"
+      '#TestGrep# -A40 "Element concentrations in curie[s]" ${OUTPUTFILENAME} | ${GREP} "totals" | ${AWK} "{print $10}"
+      '#TestGrep# -A40 "Element concentrations in watt[s]" ${OUTPUTFILENAME} | ${GREP} "totals" | ${AWK} "{print $10}"
+      '#TestGrep# -A40 "Element concentrations in gamma watt[s]" ${OUTPUTFILENAME} | ${GREP} "totals" | ${AWK} "{print $10}"
+      '#TestGrep# -A40 "Element concentrations in m3 ai[r]" ${OUTPUTFILENAME} | ${GREP} "totals" | ${AWK} "{print $10}"
+      '#TestGrep# -A40 "Element concentrations in m3 wate[r]" ${OUTPUTFILENAME} | ${GREP} "totals" | ${AWK} "{print $10}"
+      '#TestGrep# -A35 "Total (a,n / SF / delayed) neutron source spectru[m]" ${OUTPUTFILENAME} | ${GREP} "total" | ${AWK} "{print $10}"
+      '#TestRuntime# 4
+      '------------------DESCRIPTION------------------------------------------
+      '
+      ' PWR Fuel irradiated for 3 cycles of 18 months
+      '          with 40 days of decay for outage time in between
+      '          followed by 5 years of decay
+      '
+      '---------------------ARP-----------------------------------------------
+      '=arp
+      'w17x17
+      '6
+      '3
+      '540
+      '540
+      '540
+      '20
+      '19
+      '18
+      '1
+      '1
+      '1
+      '0.723
+      'w17x17_burnlib
+      'end
+      '--------------------Obiwan--------------------------------------------
+
+
+    module shell will be called on Wed Jul 13 18:08:16 2016.
+    sequence specification record:=shell
+Input Data:
+
+      /home/nsly/scale.dev/build/Linux_x86-64/INSTALL/bin/obiwan interp -idtags='Assembly Type=w17x17' -interptags='Enrichment=2.7' /home/nsly/scale_dev_data/arplibs/*
+      /home/nsly/scale.dev/build/Linux_x86-64/INSTALL/bin/obiwan convert -i -thin=1 -interp=cubic -tvals="[5400,15930,25920]" InterpLib.bof
+      'cp InterpLib.f33 w17x17_burnlib
+end
+
+WARNING: Unspecified tag 'Moderator Density' added with averaged value '0.723'.
+InterpLib.bof: {
+   idtags: {
+      Assembly Type: w17x17, 
+      Filename: InterpLib.bof   }
+   interptags: {
+      Enrichment: 2.7,    }
+}
+
+  originalFile        dataType loadedFormat convertedFile savedFormat runtime(ms)  errors
+ InterpLib.bof Origen::Library          bof InterpLib.f33         bof       1e+01       -
+module shell is finished. completion code 0
+The following data cards precede an = card
+      '--------------------ORIGEN---------DATA ENTRY IN FIRST 72 COLUMNS----->
+
+
+    module origen will be called on Wed Jul 13 18:08:23 2016.
+    sequence specification record:=origen
+Input Data:
+
+      bounds {
+          neutron="v7-27n19g"
+      }
+      
+      options {
+          digits = 6
+      }
+      
+      case(1) {
+          title="Case 1: Irradiation #1"
+      
+          lib {
+              file="InterpLib.f33"
+              pos=1
+          }
+      
+          time {
+              units="days"
+              t=[ 54 108 162 216 270 324 378 432 486 540 ]
+          }
+      
+          power=[ 20 20 20 20 20 20 20 20 20 20 ]
+      
+          mat {
+              units="GRAMS"
+              idform=zai
+              iso=[922340(2)=534 922350(2)=27000 922360(2)=276 922380(2)=972190]
+          }
+      
+          print {
+              cutoffs=[ all=1.0e-5 ]
+              nuc {
+                  sublibs=["ac"]
+                  units=["grams"]
+                  total=no
+              }
+          }
+      }
+      
+      case(2) {
+          title="Case 2 Decay #1 (Refueling -- 40 days)"
+      
+          time {
+              t=[ 540.01 540.03 540.1 540.3 541 543 550 570 580 ]
+              start=540
+          }
+      
+          print {
+              cutoffs=[ all=0.05 ]
+              nuc {
+                  sublibs=["ac"]
+                  units=["grams"]
+                  total=no
+              }
+          }
+      }
+      
+      case(3) {
+          title="Case 3: Irradiation #2"
+      
+          lib {
+              pos=2
+          }
+      
+          time {
+              t=[ 634 688 742 796 850 904 958 1012 1066 1120 ]
+              start=580
+          }
+      
+          power=[ 10r19.0 ]
+      
+          print {
+              cutoffs=[ all=1.0e-5 ]
+              nuc {
+                  sublibs=["ac"]
+                  units=["grams"]
+                  total=no
+              }
+          }
+      }
+      
+      case(4) {
+          title="Case 4 Decay #2 (Refueling -- 40 days)"
+      
+          time {
+              t=[ 1120.01 1120.03 1120.1 1120.3 1121 1123 1130 1150 1160 ]
+              start=1120
+          }
+          print {
+              nuc {
+                  sublibs=["ac"]
+                  units=["grams"]
+                  total=no
+              }
+          }
+      }
+      
+      case(5) {
+          title="Case 5: Irradiation #3"
+      
+          lib {
+              pos=3
+          }
+      
+          time {
+              t=[ 1214 1268 1322 1376 1430 1484 1538 1592 1646 1700 ]
+              start=1160
+          }
+      
+          power=[ 18 18 18 18 18 18 18 18 18 18 ]
+      
+          print {
+              cutoffs=[ all=1.0e-5 ]
+              nuc {
+                  sublibs=["ac"]
+                  units=["grams"]
+                  total=no
+              }
+          }
+      }
+      
+      case(6) {
+          title="Case 6 Decay #3 (5 years)"
+      
+          time {
+              units=days
+              t=[ 1701 1703 1710 1730 1800 2000 2700 3525 ]
+              start=1700
+          }
+      
+          print {
+              cutoffs=[ all=1.0e-2 gram-atoms=1.0e-6 grams=1.0e-6 ]
+              rel_cutoff=1
+              nuc {
+                  sublibs=["ac"]
+                  units=["grams"]
+                  total=no
+              }
+              ele {
+                  sublibs=["ac"]
+                  units=["gram-ATOMS"]
+                  total=no
+              }
+              ele {
+                  sublibs=["fp"]
+                  units=["grams" curies "watts" "G-watts" m3_AIR "m3_WATER"]
+                  total=no
+              }
+              neutron {
+                  summary=yes
+                  spectra=yes
+              }
+          }
+      
+          neutron {
+              alphan_medium=0
+          }
+      }
+end
+
+1
+
+
+
+
+
+
+        ************************************************************************************************************************
+        ************************************************************************************************************************
+        ************************************************************************************************************************
+        *****                                                                                                              *****
+        *****                                       program verification information                                       *****
+        *****                                                                                                              *****
+        *****                                   code system:  SCALE    version:  6.3                                       *****
+        *****                                                                                                              *****
+        ************************************************************************************************************************
+        ************************************************************************************************************************
+        *****                                                                                                              *****
+        *****                                                                                                              *****
+        *****              program:  origen                                                                                *****
+        *****                                                                                                              *****
+        *****        creation date:  12_jul_2016                                                                           *****
+        *****                                                                                                              *****
+        *****              library:  /home/nsly/scale.dev/build/noGtest/INSTALL/bin                                        *****
+        *****                                                                                                              *****
+        *****                                                                                                              *****
+        *****            test code:  origen                                                                                *****
+        *****                                                                                                              *****
+        *****              version:  6.3.beta1                                                                             *****
+        *****                                                                                                              *****
+        *****              jobname:  nsly                                                                                  *****
+        *****                                                                                                              *****
+        *****         machine name:  necluster.engr.utk.edu                                                                *****
+        *****                                                                                                              *****
+        *****    date of execution:  13_jul_2016                                                                           *****
+        *****                                                                                                              *****
+        *****    time of execution:  18:08:23.41                                                                           *****
+        *****                                                                                                              *****
+        *****                                                                                                              *****
+        ************************************************************************************************************************
+        ************************************************************************************************************************
+        ************************************************************************************************************************
+
+*************************************************************************************************************************
+********************                                                                                 ********************
+********************                                                                                 ********************
+********************                    USER INPUT SUMMARY                                           ********************
+********************                                                                                 ********************
+********************                                                                                 ********************
+*************************************************************************************************************************
+.
+.
+=========================================================================================================================
+=   Case "1" (#1/6)                                                                                                     =
+=   Case 1: Irradiation #1                                                                                              =
+-------------------------------------------------------------------------------------------------------------------------
+###   Library settings                                                                                                ###
+.
+                                Library file name:     /tmp/scale.nsly.28828/InterpLib.f33
+                             Library set position:              1
+                 Fission product reaction removal:             no
+-------------------------------------------------------------------------------------------------------------------------
+###   Global settings                                                                                                 ###
+.
+                                           Solver:              MATREX
+                                             Mode:        forward
+                             Fixed fission energy:             no
+-------------------------------------------------------------------------------------------------------------------------
+###   Concentrations output options                                                                                   ###
+.
+                            High-precision output:            yes
+                                  Relative cutoff:            yes
+                         Step for applying cutoff:       integral
+.
+                      light els.   actinides  fis.prods.       total
+                       nuc    el   nuc    el   nuc    el   nuc    el             cutoff
+gram-atoms                                                                    1.000E-05
+grams                              **                                         1.000E-05
+curies                                                                        1.000E-05
+watts                                                                         1.000E-05
+gamma watts                                                                   1.000E-05
+m3 air                                                                        1.000E-05
+m3 water                                                                      1.000E-05
+grams ppm                                                                     1.000E-05
+atoms ppm                                                                     1.000E-05
+atoms/barn-cm                                                                 1.000E-05
+becquerels                                                                    1.000E-05
+-------------------------------------------------------------------------------------------------------------------------
+###   Additional output options                                                                                       ###
+.
+                                      Print k-inf:             no
+           Nuclides for absorption fraction print:           none
+                              Print fission rates:             no
+            Step for sorting absorption fractions:             10
+=========================================================================================================================
+=   Case "2" (#2/6)                                                                                                     =
+=   Case 2 Decay #1 (Refueling -- 40 days)                                                                              =
+-------------------------------------------------------------------------------------------------------------------------
+###   Library settings                                                                                                ###
+.
+                                Library file name:     /tmp/scale.nsly.28828/InterpLib.f33
+                             Library set position:              1
+                 Fission product reaction removal:             no
+-------------------------------------------------------------------------------------------------------------------------
+###   Global settings                                                                                                 ###
+.
+                                           Solver:              MATREX
+                                             Mode:        forward
+                             Fixed fission energy:             no
+-------------------------------------------------------------------------------------------------------------------------
+###   Concentrations output options                                                                                   ###
+.
+                            High-precision output:            yes
+                                  Relative cutoff:            yes
+                         Step for applying cutoff:       integral
+.
+                      light els.   actinides  fis.prods.       total
+                       nuc    el   nuc    el   nuc    el   nuc    el             cutoff
+gram-atoms                                                                    5.000E-02
+grams                              **                                         5.000E-02
+curies                                                                        5.000E-02
+watts                                                                         5.000E-02
+gamma watts                                                                   5.000E-02
+m3 air                                                                        5.000E-02
+m3 water                                                                      5.000E-02
+grams ppm                                                                     5.000E-02
+atoms ppm                                                                     5.000E-02
+atoms/barn-cm                                                                 5.000E-02
+becquerels                                                                    5.000E-02
+-------------------------------------------------------------------------------------------------------------------------
+###   Additional output options                                                                                       ###
+.
+                                      Print k-inf:             no
+           Nuclides for absorption fraction print:           none
+                              Print fission rates:             no
+            Step for sorting absorption fractions:              9
+=========================================================================================================================
+=   Case "3" (#3/6)                                                                                                     =
+=   Case 3: Irradiation #2                                                                                              =
+-------------------------------------------------------------------------------------------------------------------------
+###   Library settings                                                                                                ###
+.
+                                Library file name:     /tmp/scale.nsly.28828/InterpLib.f33
+                             Library set position:              2
+                 Fission product reaction removal:             no
+-------------------------------------------------------------------------------------------------------------------------
+###   Global settings                                                                                                 ###
+.
+                                           Solver:              MATREX
+                                             Mode:        forward
+                             Fixed fission energy:             no
+-------------------------------------------------------------------------------------------------------------------------
+###   Concentrations output options                                                                                   ###
+.
+                            High-precision output:            yes
+                                  Relative cutoff:            yes
+                         Step for applying cutoff:       integral
+.
+                      light els.   actinides  fis.prods.       total
+                       nuc    el   nuc    el   nuc    el   nuc    el             cutoff
+gram-atoms                                                                    1.000E-05
+grams                              **                                         1.000E-05
+curies                                                                        1.000E-05
+watts                                                                         1.000E-05
+gamma watts                                                                   1.000E-05
+m3 air                                                                        1.000E-05
+m3 water                                                                      1.000E-05
+grams ppm                                                                     1.000E-05
+atoms ppm                                                                     1.000E-05
+atoms/barn-cm                                                                 1.000E-05
+becquerels                                                                    1.000E-05
+-------------------------------------------------------------------------------------------------------------------------
+###   Additional output options                                                                                       ###
+.
+                                      Print k-inf:             no
+           Nuclides for absorption fraction print:           none
+                              Print fission rates:             no
+            Step for sorting absorption fractions:             10
+=========================================================================================================================
+=   Case "4" (#4/6)                                                                                                     =
+=   Case 4 Decay #2 (Refueling -- 40 days)                                                                              =
+-------------------------------------------------------------------------------------------------------------------------
+###   Library settings                                                                                                ###
+.
+                                Library file name:     /tmp/scale.nsly.28828/InterpLib.f33
+                             Library set position:              2
+                 Fission product reaction removal:             no
+-------------------------------------------------------------------------------------------------------------------------
+###   Global settings                                                                                                 ###
+.
+                                           Solver:              MATREX
+                                             Mode:        forward
+                             Fixed fission energy:             no
+-------------------------------------------------------------------------------------------------------------------------
+###   Concentrations output options                                                                                   ###
+.
+                            High-precision output:            yes
+                                  Relative cutoff:            yes
+                         Step for applying cutoff:       integral
+.
+                      light els.   actinides  fis.prods.       total
+                       nuc    el   nuc    el   nuc    el   nuc    el             cutoff
+gram-atoms                                                                    1.000E-06
+grams                              **                                         1.000E-06
+curies                                                                        1.000E-06
+watts                                                                         1.000E-06
+gamma watts                                                                   1.000E-06
+m3 air                                                                        1.000E-06
+m3 water                                                                      1.000E-06
+grams ppm                                                                     1.000E-06
+atoms ppm                                                                     1.000E-06
+atoms/barn-cm                                                                 1.000E-06
+becquerels                                                                    1.000E-06
+-------------------------------------------------------------------------------------------------------------------------
+###   Additional output options                                                                                       ###
+.
+                                      Print k-inf:             no
+           Nuclides for absorption fraction print:           none
+                              Print fission rates:             no
+            Step for sorting absorption fractions:              9
+=========================================================================================================================
+=   Case "5" (#5/6)                                                                                                     =
+=   Case 5: Irradiation #3                                                                                              =
+-------------------------------------------------------------------------------------------------------------------------
+###   Library settings                                                                                                ###
+.
+                                Library file name:     /tmp/scale.nsly.28828/InterpLib.f33
+                             Library set position:              3
+                 Fission product reaction removal:             no
+-------------------------------------------------------------------------------------------------------------------------
+###   Global settings                                                                                                 ###
+.
+                                           Solver:              MATREX
+                                             Mode:        forward
+                             Fixed fission energy:             no
+-------------------------------------------------------------------------------------------------------------------------
+###   Concentrations output options                                                                                   ###
+.
+                            High-precision output:            yes
+                                  Relative cutoff:            yes
+                         Step for applying cutoff:       integral
+.
+                      light els.   actinides  fis.prods.       total
+                       nuc    el   nuc    el   nuc    el   nuc    el             cutoff
+gram-atoms                                                                    1.000E-05
+grams                              **                                         1.000E-05
+curies                                                                        1.000E-05
+watts                                                                         1.000E-05
+gamma watts                                                                   1.000E-05
+m3 air                                                                        1.000E-05
+m3 water                                                                      1.000E-05
+grams ppm                                                                     1.000E-05
+atoms ppm                                                                     1.000E-05
+atoms/barn-cm                                                                 1.000E-05
+becquerels                                                                    1.000E-05
+-------------------------------------------------------------------------------------------------------------------------
+###   Additional output options                                                                                       ###
+.
+                                      Print k-inf:             no
+           Nuclides for absorption fraction print:           none
+                              Print fission rates:             no
+            Step for sorting absorption fractions:             10
+=========================================================================================================================
+=   Case "6" (#6/6)                                                                                                     =
+=   Case 6 Decay #3 (5 years)                                                                                           =
+-------------------------------------------------------------------------------------------------------------------------
+###   Library settings                                                                                                ###
+.
+                                Library file name:     /tmp/scale.nsly.28828/InterpLib.f33
+                             Library set position:              3
+                 Fission product reaction removal:             no
+-------------------------------------------------------------------------------------------------------------------------
+###   Global settings                                                                                                 ###
+.
+                                           Solver:              MATREX
+                                             Mode:        forward
+                             Fixed fission energy:             no
+-------------------------------------------------------------------------------------------------------------------------
+###   Concentrations output options                                                                                   ###
+.
+                            High-precision output:            yes
+                                  Relative cutoff:            yes
+                         Step for applying cutoff:       integral
+.
+                      light els.   actinides  fis.prods.       total
+                       nuc    el   nuc    el   nuc    el   nuc    el             cutoff
+gram-atoms                               **                                   1.000E-06
+grams                              **                **                       1.000E-06
+curies                                               **                       1.000E-02
+watts                                                **                       1.000E-02
+gamma watts                                          **                       1.000E-02
+m3 air                                               **                       1.000E-02
+m3 water                                             **                       1.000E-02
+grams ppm                                                                     1.000E-02
+atoms ppm                                                                     1.000E-02
+atoms/barn-cm                                                                 1.000E-02
+becquerels                                                                    1.000E-02
+-------------------------------------------------------------------------------------------------------------------------
+###   Additional output options                                                                                       ###
+.
+                                      Print k-inf:             no
+           Nuclides for absorption fraction print:           none
+                              Print fission rates:             no
+            Step for sorting absorption fractions:              8
+-------------------------------------------------------------------------------------------------------------------------
+###   Neutron calculation                                                                                             ###
+.
+                          Number of energy groups:             27
+                            Print neutron sources:            yes
+                            Print neutron spectra:            yes
+                        Print neutron source info:             no
+                             Number of (a,n) bins:            200
+                    Medium for (a,n) calculations:            UO2
+                                 Cutoff for (a,n):       1.00E-05
+          Step for the case-specific (a,n) matrix:              8
+=========================================================================================================================
+###   Blending information                                                                                            ###
+.
+  --- no blending requested in this job ---
+=========================================================================================================================
+.
+.
+=========================================================================================================================
+=   History overview for case '1' (#1/6)                                                                                =
+=   Case 1: Irradiation #1                                                                                              =
+-------------------------------------------------------------------------------------------------------------------------
+   step            t0            t1            dt             t          flux       fluence         power        energy
+    (-)           (d)           (d)           (s)           (s)     (n/cm2-s)       (n/cm2)          (MW)         (MWd)
+      1      0.000000     54.000000  4.665600E+06  4.665600E+06  2.788517E+13  1.301010E+20  2.000000E+01  1.080000E+03
+      2     54.000000    108.000000  4.665600E+06  9.331200E+06  2.756233E+13  2.586958E+20  2.000000E+01  2.160000E+03
+      3    108.000000    162.000000  4.665600E+06  1.399680E+07  2.735369E+13  3.863172E+20  2.000000E+01  3.240000E+03
+      4    162.000000    216.000000  4.665600E+06  1.866240E+07  2.724669E+13  5.134394E+20  2.000000E+01  4.320000E+03
+      5    216.000000    270.000000  4.665600E+06  2.332800E+07  2.721539E+13  6.404155E+20  2.000000E+01  5.400000E+03
+      6    270.000000    324.000000  4.665600E+06  2.799360E+07  2.724187E+13  7.675152E+20  2.000000E+01  6.480000E+03
+      7    324.000000    378.000000  4.665600E+06  3.265920E+07  2.731339E+13  8.949485E+20  2.000000E+01  7.560000E+03
+      8    378.000000    432.000000  4.665600E+06  3.732480E+07  2.742073E+13  1.022883E+21  2.000000E+01  8.640000E+03
+      9    432.000000    486.000000  4.665600E+06  4.199040E+07  2.755706E+13  1.151453E+21  2.000000E+01  9.720000E+03
+     10    486.000000    540.000000  4.665600E+06  4.665600E+07  2.771727E+13  1.280771E+21  2.000000E+01  1.080000E+04
+          
+              step - step index within this case
+                t0 - time at beginning-of-step in input units
+                t1 - time at end-of-step in input units
+                dt - length of step in seconds
+                 t - end-of-step cumulative time in seconds
+              flux - flux in neutrons/cm^2-sec (CALCULATED)
+           fluence - cumulative end-of-step fluence in neutrons/cm^2 (CALCULATED)
+             power - power in mega-watts (INPUT)     
+            energy - cumulative end-of-step energy released in mega-watt-days (INPUT)     
+=========================================================================================================================
+.
+.
+.
+.
+.
+*************************************************************************************************************************
+********************                                                                                 ********************
+********************                                                                                 ********************
+********************                    Library information                                          ********************
+********************                                                                                 ********************
+********************                                                                                 ********************
+*************************************************************************************************************************
+.
+.
+=========================================================================================================================
+=   Library summary for case '1' (#1/6)                                                                                 =
+=   Case 1: Irradiation #1                                                                                              =
+-------------------------------------------------------------------------------------------------------------------------
+filename: /tmp/scale.nsly.28828/InterpLib.f33 cross-section data taken from position number: 1
+library title delimited by {}: 
+{}
+date library was produced: 5/30/2006
+total number of nuclides in library: 1946
+number of light-element nuclides: 698
+number of actinide nuclides: 129
+number of fission product nuclides: 1119
+number of nonzero off-diagonal matrix elements: 35013
+=========================================================================================================================
+.
+.
+*************************************************************************************************************************
+********************                                                                                 ********************
+********************                                                                                 ********************
+********************                    Concentration tables                                         ********************
+********************                                                                                 ********************
+********************                                                                                 ********************
+*************************************************************************************************************************
+.
+.
+=========================================================================================================================
+=   Nuclide concentrations in grams, actinides for case '1' (#1/6)                                                      =
+=   Case 1: Irradiation #1                                                                                              =
+-------------------------------------------------------------------------------------------------------------------------
+  (relative cutoff; integral of concentrations over time >   1.00E-05 % of integral of all concentrations over time)
+.
+                   0.000d       54.000d      108.000d      162.000d      216.000d      270.000d      324.000d      378.000d      432.000d      486.000d      540.000d   
+  u-234        5.340000E+02  5.242920E+02  5.148686E+02  5.056831E+02  4.966959E+02  4.878782E+02  4.792089E+02  4.706720E+02  4.622555E+02  4.539502E+02  4.457490E+02
+  u-235        2.700000E+04  2.574617E+04  2.456434E+04  2.344536E+04  2.238168E+04  2.136764E+04  2.039885E+04  1.947185E+04  1.858381E+04  1.773238E+04  1.691558E+04
+  u-236        2.760000E+02  5.043826E+02  7.181002E+02  9.189408E+02  1.108366E+03  1.287478E+03  1.457127E+03  1.617996E+03  1.770637E+03  1.915515E+03  2.053024E+03
+  u-237        0.000000E+00  1.192375E+00  1.432568E+00  1.655152E+00  1.867770E+00  2.072406E+00  2.270358E+00  2.462509E+00  2.649473E+00  2.831685E+00  3.009466E+00
+  u-238        9.721900E+05  9.713885E+05  9.705969E+05  9.698119E+05  9.690307E+05  9.682510E+05  9.674712E+05  9.666899E+05  9.659063E+05  9.651194E+05  9.643285E+05
+  u-239        0.000000E+00  3.143198E-01  3.104276E-01  3.078286E-01  3.063775E-01  3.057793E-01  3.058302E-01  3.063856E-01  3.073403E-01  3.086167E-01  3.101566E-01
+  np-237       0.000000E+00  4.909724E+00  1.192390E+01  1.999379E+01  2.902262E+01  3.893250E+01  4.965513E+01  6.112883E+01  7.329666E+01  8.610521E+01  9.950382E+01
+  np-239       0.000000E+00  4.538722E+01  4.482569E+01  4.445071E+01  4.424133E+01  4.415501E+01  4.416235E+01  4.424246E+01  4.438018E+01  4.456431E+01  4.478646E+01
+  pu-238       0.000000E+00  5.797957E-02  2.959945E-01  7.444561E-01  1.425978E+00  2.362628E+00  3.576500E+00  5.090033E+00  6.926139E+00  9.108169E+00  1.165976E+01
+  pu-239       0.000000E+00  6.275240E+02  1.200833E+03  1.690804E+03  2.111378E+03  2.473468E+03  2.785819E+03  3.055578E+03  3.288682E+03  3.490128E+03  3.664160E+03
+  pu-240       0.000000E+00  1.716095E+01  6.239942E+01  1.268802E+02  2.040881E+02  2.891895E+02  3.785553E+02  4.694490E+02  5.598125E+02  6.481126E+02  7.332286E+02
+  pu-241       0.000000E+00  9.230485E-01  6.496316E+00  1.944394E+01  4.103151E+01  7.158265E+01  1.108104E+02  1.580359E+02  2.123387E+02  2.726632E+02  3.378951E+02
+  pu-242       0.000000E+00  9.178045E-03  1.286469E-01  5.838253E-01  1.664932E+00  3.684542E+00  6.951543E+00  1.175472E+01  1.835242E+01  2.696627E+01  3.777783E+01
+  am-241       0.000000E+00  1.679617E-03  2.346529E-02  1.056759E-01  2.981575E-01  6.513552E-01  1.210963E+00  2.014854E+00  3.091518E+00  4.459516E+00  6.127616E+00
+  am-243       0.000000E+00  5.348130E-05  1.487051E-03  1.016106E-02  3.887565E-02  1.083155E-01  2.471413E-01  4.915680E-01  8.846187E-01  1.475173E+00  2.316887E+00
+  cm-242       0.000000E+00  2.192573E-05  5.892845E-04  3.880794E-03  1.427759E-02  3.819312E-02  8.357756E-02  1.593130E-01  2.746105E-01  4.384666E-01  6.592063E-01
+------------
+  totals       1.000000E+06  9.988608E+05  9.977229E+05  9.965870E+05  9.954529E+05  9.943206E+05  9.931901E+05  9.920613E+05  9.909342E+05  9.898087E+05  9.886848E+05
+=========================================================================================================================
+.
+.
+=========================================================================================================================
+=   History overview for case '2' (#2/6)                                                                                =
+=   Case 2 Decay #1 (Refueling -- 40 days)                                                                              =
+-------------------------------------------------------------------------------------------------------------------------
+   step            t0            t1            dt             t          flux       fluence         power        energy
+    (-)           (d)           (d)           (s)           (s)     (n/cm2-s)       (n/cm2)          (MW)         (MWd)
+      1    540.000000    540.010010  8.640000E+02  4.665686E+07  0.000000E+00  1.280771E+21  0.000000E+00  1.080000E+04
+      2    540.010010    540.030029  1.728000E+03  4.665859E+07  0.000000E+00  1.280771E+21  0.000000E+00  1.080000E+04
+      3    540.030029    540.099976  6.048000E+03  4.666464E+07  0.000000E+00  1.280771E+21  0.000000E+00  1.080000E+04
+      4    540.099976    540.299988  1.728000E+04  4.668192E+07  0.000000E+00  1.280771E+21  0.000000E+00  1.080000E+04
+      5    540.299988    541.000000  6.048000E+04  4.674240E+07  0.000000E+00  1.280771E+21  0.000000E+00  1.080000E+04
+      6    541.000000    543.000000  1.728000E+05  4.691520E+07  0.000000E+00  1.280771E+21  0.000000E+00  1.080000E+04
+      7    543.000000    550.000000  6.048000E+05  4.752000E+07  0.000000E+00  1.280771E+21  0.000000E+00  1.080000E+04
+      8    550.000000    570.000000  1.728000E+06  4.924800E+07  0.000000E+00  1.280771E+21  0.000000E+00  1.080000E+04
+      9    570.000000    580.000000  8.640000E+05  5.011200E+07  0.000000E+00  1.280771E+21  0.000000E+00  1.080000E+04
+          
+              step - step index within this case
+                t0 - time at beginning-of-step in input units
+                t1 - time at end-of-step in input units
+                dt - length of step in seconds
+                 t - end-of-step cumulative time in seconds
+              flux - flux in neutrons/cm^2-sec (CALCULATED)
+           fluence - cumulative end-of-step fluence in neutrons/cm^2 (CALCULATED)
+             power - power in mega-watts (INPUT)     
+            energy - cumulative end-of-step energy released in mega-watt-days (INPUT)     
+=========================================================================================================================
+.
+.
+.
+.
+.
+*************************************************************************************************************************
+********************                                                                                 ********************
+********************                                                                                 ********************
+********************                    Library information                                          ********************
+********************                                                                                 ********************
+********************                                                                                 ********************
+*************************************************************************************************************************
+.
+.
+=========================================================================================================================
+=   Library summary for case '2' (#2/6)                                                                                 =
+=   Case 2 Decay #1 (Refueling -- 40 days)                                                                              =
+-------------------------------------------------------------------------------------------------------------------------
+filename: /tmp/scale.nsly.28828/InterpLib.f33 cross-section data taken from position number: 1
+library title delimited by {}: 
+{}
+date library was produced: 5/30/2006
+total number of nuclides in library: 1946
+number of light-element nuclides: 698
+number of actinide nuclides: 129
+number of fission product nuclides: 1119
+number of nonzero off-diagonal matrix elements: 35013
+=========================================================================================================================
+.
+.
+*************************************************************************************************************************
+********************                                                                                 ********************
+********************                                                                                 ********************
+********************                    Concentration tables                                         ********************
+********************                                                                                 ********************
+********************                                                                                 ********************
+*************************************************************************************************************************
+.
+.
+=========================================================================================================================
+=   Nuclide concentrations in grams, actinides for case '2' (#2/6)                                                      =
+=   Case 2 Decay #1 (Refueling -- 40 days)                                                                              =
+-------------------------------------------------------------------------------------------------------------------------
+  (relative cutoff; integral of concentrations over time >   5.00E-02 % of integral of all concentrations over time)
+.
+                 540.000d      540.010d      540.030d      540.100d      540.300d      541.000d      543.000d      550.000d      570.000d      580.000d   
+  u-235        1.691558E+04  1.691558E+04  1.691558E+04  1.691558E+04  1.691558E+04  1.691558E+04  1.691558E+04  1.691558E+04  1.691559E+04  1.691559E+04
+  u-236        2.053024E+03  2.053024E+03  2.053024E+03  2.053024E+03  2.053024E+03  2.053024E+03  2.053025E+03  2.053026E+03  2.053030E+03  2.053032E+03
+  u-238        9.643285E+05  9.643285E+05  9.643285E+05  9.643285E+05  9.643285E+05  9.643285E+05  9.643285E+05  9.643285E+05  9.643285E+05  9.643285E+05
+  pu-239       3.664160E+03  3.664292E+03  3.664555E+03  3.665466E+03  3.667968E+03  3.675655E+03  3.690603E+03  3.706876E+03  3.709241E+03  3.709244E+03
+  pu-240       7.332286E+02  7.332287E+02  7.332288E+02  7.332291E+02  7.332292E+02  7.332291E+02  7.332287E+02  7.332274E+02  7.332235E+02  7.332215E+02
+------------
+  totals       9.886848E+05  9.886848E+05  9.886848E+05  9.886848E+05  9.886848E+05  9.886848E+05  9.886848E+05  9.886848E+05  9.886848E+05  9.886848E+05
+=========================================================================================================================
+.
+.
+=========================================================================================================================
+=   History overview for case '3' (#3/6)                                                                                =
+=   Case 3: Irradiation #2                                                                                              =
+-------------------------------------------------------------------------------------------------------------------------
+   step            t0            t1            dt             t          flux       fluence         power        energy
+    (-)           (d)           (d)           (s)           (s)     (n/cm2-s)       (n/cm2)          (MW)         (MWd)
+      1  5.800000E+02  6.340000E+02  4.665600E+06  5.477760E+07  2.616445E+13  1.402843E+21  1.900000E+01  1.182600E+04
+      2  6.340000E+02  6.880000E+02  4.665600E+06  5.944320E+07  2.632896E+13  1.525684E+21  1.900000E+01  1.285200E+04
+      3  6.880000E+02  7.420000E+02  4.665600E+06  6.410880E+07  2.648115E+13  1.649234E+21  1.900000E+01  1.387800E+04
+      4  7.420000E+02  7.960000E+02  4.665600E+06  6.877440E+07  2.664598E+13  1.773554E+21  1.900000E+01  1.490400E+04
+      5  7.960000E+02  8.500000E+02  4.665600E+06  7.344000E+07  2.682121E+13  1.898691E+21  1.900000E+01  1.593000E+04
+      6  8.500000E+02  9.040000E+02  4.665600E+06  7.810560E+07  2.700506E+13  2.024686E+21  1.900000E+01  1.695600E+04
+      7  9.040000E+02  9.580000E+02  4.665600E+06  8.277120E+07  2.719607E+13  2.151572E+21  1.900000E+01  1.798200E+04
+      8  9.580000E+02  1.012000E+03  4.665600E+06  8.743680E+07  2.739306E+13  2.279377E+21  1.900000E+01  1.900800E+04
+      9  1.012000E+03  1.066000E+03  4.665600E+06  9.210240E+07  2.759504E+13  2.408124E+21  1.900000E+01  2.003400E+04
+     10  1.066000E+03  1.120000E+03  4.665600E+06  9.676800E+07  2.780122E+13  2.537834E+21  1.900000E+01  2.106000E+04
+          
+              step - step index within this case
+                t0 - time at beginning-of-step in input units
+                t1 - time at end-of-step in input units
+                dt - length of step in seconds
+                 t - end-of-step cumulative time in seconds
+              flux - flux in neutrons/cm^2-sec (CALCULATED)
+           fluence - cumulative end-of-step fluence in neutrons/cm^2 (CALCULATED)
+             power - power in mega-watts (INPUT)     
+            energy - cumulative end-of-step energy released in mega-watt-days (INPUT)     
+=========================================================================================================================
+.
+.
+.
+.
+.
+*************************************************************************************************************************
+********************                                                                                 ********************
+********************                                                                                 ********************
+********************                    Library information                                          ********************
+********************                                                                                 ********************
+********************                                                                                 ********************
+*************************************************************************************************************************
+.
+.
+=========================================================================================================================
+=   Library summary for case '3' (#3/6)                                                                                 =
+=   Case 3: Irradiation #2                                                                                              =
+-------------------------------------------------------------------------------------------------------------------------
+filename: /tmp/scale.nsly.28828/InterpLib.f33 cross-section data taken from position number: 2
+library title delimited by {}: 
+{}
+date library was produced: 5/30/2006
+total number of nuclides in library: 1946
+number of light-element nuclides: 698
+number of actinide nuclides: 129
+number of fission product nuclides: 1119
+number of nonzero off-diagonal matrix elements: 35013
+=========================================================================================================================
+.
+.
+*************************************************************************************************************************
+********************                                                                                 ********************
+********************                                                                                 ********************
+********************                    Concentration tables                                         ********************
+********************                                                                                 ********************
+********************                                                                                 ********************
+*************************************************************************************************************************
+.
+.
+=========================================================================================================================
+=   Nuclide concentrations in grams, actinides for case '3' (#3/6)                                                      =
+=   Case 3: Irradiation #2                                                                                              =
+-------------------------------------------------------------------------------------------------------------------------
+  (relative cutoff; integral of concentrations over time >   1.00E-05 % of integral of all concentrations over time)
+.
+                 580.000d      634.000d      688.000d      742.000d      796.000d      850.000d      904.000d      958.000d     1012.000d     1066.000d     1120.000d   
+  u-234        4.457590E+02  4.378711E+02  4.300772E+02  4.223816E+02  4.147808E+02  4.072725E+02  3.998550E+02  3.925271E+02  3.852880E+02  3.781373E+02  3.710746E+02
+  u-235        1.691559E+04  1.616383E+04  1.544128E+04  1.474733E+04  1.408075E+04  1.344040E+04  1.282529E+04  1.223447E+04  1.166709E+04  1.112232E+04  1.059940E+04
+  u-236        2.053032E+03  2.180550E+03  2.301769E+03  2.416837E+03  2.526007E+03  2.629508E+03  2.727551E+03  2.820330E+03  2.908027E+03  2.990814E+03  3.068855E+03
+  u-237        4.950951E-02  3.026898E+00  3.189769E+00  3.335336E+00  3.477365E+00  3.615920E+00  3.751000E+00  3.882603E+00  4.010720E+00  4.135347E+00  4.256478E+00
+  u-238        9.643285E+05  9.635221E+05  9.627113E+05  9.618964E+05  9.610773E+05  9.602534E+05  9.594246E+05  9.585907E+05  9.577515E+05  9.569068E+05  9.560566E+05
+  u-239        0.000000E+00  3.152831E-01  3.169984E-01  3.185610E-01  3.202708E-01  3.221006E-01  3.240286E-01  3.260369E-01  3.281109E-01  3.302388E-01  3.324105E-01
+  np-237       1.024650E+02  1.129383E+02  1.266562E+02  1.407702E+02  1.552292E+02  1.699960E+02  1.850348E+02  2.003105E+02  2.157886E+02  2.314356E+02  2.472190E+02
+  np-238       3.628446E-07  1.863672E-01  2.103036E-01  2.350839E-01  2.608355E-01  2.875171E-01  3.150859E-01  3.434967E-01  3.727033E-01  4.026581E-01  4.333122E-01
+  np-239       3.501848E-04  4.552649E+01  4.577394E+01  4.599935E+01  4.624600E+01  4.650997E+01  4.678808E+01  4.707778E+01  4.737696E+01  4.768390E+01  4.799717E+01
+  pu-238       1.192094E+01  1.460457E+01  1.783754E+01  2.147879E+01  2.553765E+01  3.002316E+01  3.494387E+01  4.030769E+01  4.612175E+01  5.239217E+01  5.912387E+01
+  pu-239       3.709244E+03  3.866987E+03  4.045070E+03  4.200520E+03  4.336065E+03  4.454133E+03  4.556851E+03  4.646089E+03  4.723491E+03  4.790509E+03  4.848423E+03
+  pu-240       7.332215E+02  8.341081E+02  9.337972E+02  1.031312E+03  1.125887E+03  1.216939E+03  1.304038E+03  1.386879E+03  1.465266E+03  1.539090E+03  1.608318E+03
+  pu-241       3.361122E+02  3.736083E+02  4.168828E+02  4.650370E+02  5.172295E+02  5.726456E+02  6.305098E+02  6.900961E+02  7.507338E+02  8.118120E+02  8.727820E+02
+  pu-242       3.777935E+01  4.934482E+01  6.211794E+01  7.626222E+01  9.192253E+01  1.092126E+02  1.282160E+02  1.489880E+02  1.715571E+02  1.959274E+02  2.220803E+02
+  am-241       7.909289E+00  9.648768E+00  1.150904E+01  1.351443E+01  1.568004E+01  1.801359E+01  2.051628E+01  2.318368E+01  2.600658E+01  2.897190E+01  3.206341E+01
+  am-242m      9.049154E-02  1.393162E-01  1.833076E-01  2.262414E-01  2.702938E-01  3.166944E-01  3.661133E-01  4.188686E-01  4.750428E-01  5.345515E-01  5.971872E-01
+  am-243       2.322774E+00  3.442976E+00  4.875226E+00  6.640195E+00  8.769934E+00  1.129985E+01  1.426764E+01  1.771236E+01  2.167354E+01  2.619038E+01  3.130098E+01
+  cm-242       5.622590E-01  9.217068E-01  1.315514E+00  1.737988E+00  2.193319E+00  2.685705E+00  3.218962E+00  3.796265E+00  4.419974E+00  5.091543E+00  5.811479E+00
+  cm-244       1.776380E-01  2.871289E-01  4.475913E-01  6.705295E-01  9.698627E-01  1.360981E+00  1.860879E+00  2.488253E+00  3.263557E+00  4.209025E+00  5.348660E+00
+------------
+  totals       9.886848E+05  9.876195E+05  9.865546E+05  9.854912E+05  9.844290E+05  9.833681E+05  9.823085E+05  9.812502E+05  9.801931E+05  9.791372E+05  9.780825E+05
+=========================================================================================================================
+.
+.
+=========================================================================================================================
+=   History overview for case '4' (#4/6)                                                                                =
+=   Case 4 Decay #2 (Refueling -- 40 days)                                                                              =
+-------------------------------------------------------------------------------------------------------------------------
+   step            t0            t1            dt             t          flux       fluence         power        energy
+    (-)           (d)           (d)           (s)           (s)     (n/cm2-s)       (n/cm2)          (MW)         (MWd)
+      1  1.120000E+03  1.120010E+03  8.640000E+02  9.676886E+07  0.000000E+00  2.537834E+21  0.000000E+00  2.106000E+04
+      2  1.120010E+03  1.120030E+03  1.728000E+03  9.677059E+07  0.000000E+00  2.537834E+21  0.000000E+00  2.106000E+04
+      3  1.120030E+03  1.120100E+03  6.048000E+03  9.677664E+07  0.000000E+00  2.537834E+21  0.000000E+00  2.106000E+04
+      4  1.120100E+03  1.120300E+03  1.728000E+04  9.679392E+07  0.000000E+00  2.537834E+21  0.000000E+00  2.106000E+04
+      5  1.120300E+03  1.121000E+03  6.048000E+04  9.685440E+07  0.000000E+00  2.537834E+21  0.000000E+00  2.106000E+04
+      6  1.121000E+03  1.123000E+03  1.728000E+05  9.702720E+07  0.000000E+00  2.537834E+21  0.000000E+00  2.106000E+04
+      7  1.123000E+03  1.130000E+03  6.048000E+05  9.763200E+07  0.000000E+00  2.537834E+21  0.000000E+00  2.106000E+04
+      8  1.130000E+03  1.150000E+03  1.728000E+06  9.936000E+07  0.000000E+00  2.537834E+21  0.000000E+00  2.106000E+04
+      9  1.150000E+03  1.160000E+03  8.640000E+05  1.002240E+08  0.000000E+00  2.537834E+21  0.000000E+00  2.106000E+04
+          
+              step - step index within this case
+                t0 - time at beginning-of-step in input units
+                t1 - time at end-of-step in input units
+                dt - length of step in seconds
+                 t - end-of-step cumulative time in seconds
+              flux - flux in neutrons/cm^2-sec (CALCULATED)
+           fluence - cumulative end-of-step fluence in neutrons/cm^2 (CALCULATED)
+             power - power in mega-watts (INPUT)     
+            energy - cumulative end-of-step energy released in mega-watt-days (INPUT)     
+=========================================================================================================================
+.
+.
+.
+.
+.
+*************************************************************************************************************************
+********************                                                                                 ********************
+********************                                                                                 ********************
+********************                    Library information                                          ********************
+********************                                                                                 ********************
+********************                                                                                 ********************
+*************************************************************************************************************************
+.
+.
+=========================================================================================================================
+=   Library summary for case '4' (#4/6)                                                                                 =
+=   Case 4 Decay #2 (Refueling -- 40 days)                                                                              =
+-------------------------------------------------------------------------------------------------------------------------
+filename: /tmp/scale.nsly.28828/InterpLib.f33 cross-section data taken from position number: 2
+library title delimited by {}: 
+{}
+date library was produced: 5/30/2006
+total number of nuclides in library: 1946
+number of light-element nuclides: 698
+number of actinide nuclides: 129
+number of fission product nuclides: 1119
+number of nonzero off-diagonal matrix elements: 35013
+=========================================================================================================================
+.
+.
+*************************************************************************************************************************
+********************                                                                                 ********************
+********************                                                                                 ********************
+********************                    Concentration tables                                         ********************
+********************                                                                                 ********************
+********************                                                                                 ********************
+*************************************************************************************************************************
+.
+.
+=========================================================================================================================
+=   Nuclide concentrations in grams, actinides for case '4' (#4/6)                                                      =
+=   Case 4 Decay #2 (Refueling -- 40 days)                                                                              =
+-------------------------------------------------------------------------------------------------------------------------
+  (relative cutoff; integral of concentrations over time >   1.00E-06 % of integral of all concentrations over time)
+.
+                1120.000d     1120.010d     1120.030d     1120.100d     1120.300d     1121.000d     1123.000d     1130.000d     1150.000d     1160.000d   
+  he-4         1.344090E-01  1.344136E-01  1.344227E-01  1.344547E-01  1.345460E-01  1.348655E-01  1.357760E-01  1.389124E-01  1.474341E-01  1.514629E-01
+  u-234        3.710746E+02  3.710746E+02  3.710747E+02  3.710748E+02  3.710750E+02  3.710759E+02  3.710784E+02  3.710873E+02  3.711127E+02  3.711255E+02
+  u-235        1.059940E+04  1.059940E+04  1.059940E+04  1.059940E+04  1.059940E+04  1.059940E+04  1.059940E+04  1.059941E+04  1.059941E+04  1.059942E+04
+  u-236        3.068855E+03  3.068855E+03  3.068855E+03  3.068855E+03  3.068855E+03  3.068855E+03  3.068856E+03  3.068859E+03  3.068868E+03  3.068873E+03
+  u-237        4.256478E+00  4.252109E+00  4.243385E+00  4.212992E+00  4.127350E+00  3.841081E+00  3.127949E+00  1.524344E+00  1.955193E-01  7.003613E-02
+  u-238        9.560566E+05  9.560566E+05  9.560566E+05  9.560566E+05  9.560566E+05  9.560566E+05  9.560566E+05  9.560566E+05  9.560566E+05  9.560566E+05
+  np-237       2.472190E+02  2.472234E+02  2.472321E+02  2.472625E+02  2.473482E+02  2.476345E+02  2.483479E+02  2.499526E+02  2.512844E+02  2.514115E+02
+  np-238       4.333122E-01  4.318957E-01  4.290766E-01  4.193538E-01  3.927713E-01  3.123180E-01  1.622517E-01  1.639700E-02  2.358778E-05  9.970423E-07
+  np-239       4.799717E+01  4.797111E+01  4.781363E+01  4.692550E+01  4.424775E+01  3.601016E+01  1.998976E+01  2.547709E+00  7.105912E-03  4.001121E-04
+  pu-238       5.912387E+01  5.912551E+01  5.912879E+01  5.914013E+01  5.917132E+01  5.926790E+01  5.946386E+01  5.976729E+01  6.020728E+01  6.040511E+01
+  pu-239       4.848423E+03  4.848564E+03  4.848846E+03  4.849822E+03  4.852504E+03  4.860742E+03  4.876761E+03  4.894201E+03  4.896734E+03  4.896737E+03
+  pu-240       1.608318E+03  1.608318E+03  1.608319E+03  1.608319E+03  1.608319E+03  1.608319E+03  1.608319E+03  1.608320E+03  1.608322E+03  1.608323E+03
+  pu-241       8.727820E+02  8.727808E+02  8.727785E+02  8.727705E+02  8.727474E+02  8.726666E+02  8.724358E+02  8.716284E+02  8.693258E+02  8.681768E+02
+  pu-242       2.220803E+02  2.220804E+02  2.220806E+02  2.220811E+02  2.220824E+02  2.220854E+02  2.220878E+02  2.220882E+02  2.220882E+02  2.220882E+02
+  am-241       3.206341E+01  3.206456E+01  3.206687E+01  3.207494E+01  3.209799E+01  3.217869E+01  3.240922E+01  3.321557E+01  3.551517E+01  3.666261E+01
+  am-242m      5.971872E-01  5.971871E-01  5.971869E-01  5.971864E-01  5.971848E-01  5.971791E-01  5.971631E-01  5.971068E-01  5.969461E-01  5.968658E-01
+  am-243       3.130098E+01  3.130219E+01  3.130450E+01  3.131147E+01  3.132433E+01  3.133648E+01  3.133775E+01  3.133769E+01  3.133753E+01  3.133745E+01
+  cm-242       5.811479E+00  5.811620E+00  5.811891E+00  5.812718E+00  5.814133E+00  5.811060E+00  5.773431E+00  5.605738E+00  5.148715E+00  4.934375E+00
+  cm-243       1.016639E-01  1.016638E-01  1.016636E-01  1.016632E-01  1.016618E-01  1.016571E-01  1.016435E-01  1.015962E-01  1.014610E-01  1.013934E-01
+  cm-244       5.348660E+00  5.348899E+00  5.349365E+00  5.350878E+00  5.354330E+00  5.360188E+00  5.361840E+00  5.358013E+00  5.346790E+00  5.341187E+00
+  cm-245       1.363926E-01  1.363926E-01  1.363926E-01  1.363926E-01  1.363926E-01  1.363927E-01  1.363926E-01  1.363924E-01  1.363918E-01  1.363915E-01
+------------
+  totals       9.780825E+05  9.780825E+05  9.780825E+05  9.780825E+05  9.780825E+05  9.780825E+05  9.780825E+05  9.780825E+05  9.780825E+05  9.780825E+05
+=========================================================================================================================
+.
+.
+=========================================================================================================================
+=   History overview for case '5' (#5/6)                                                                                =
+=   Case 5: Irradiation #3                                                                                              =
+-------------------------------------------------------------------------------------------------------------------------
+   step            t0            t1            dt             t          flux       fluence         power        energy
+    (-)           (d)           (d)           (s)           (s)     (n/cm2-s)       (n/cm2)          (MW)         (MWd)
+      1  1.160000E+03  1.214000E+03  4.665600E+06  1.048896E+08  2.643228E+13  2.661156E+21  1.800000E+01  2.203200E+04
+      2  1.214000E+03  1.268000E+03  4.665600E+06  1.095552E+08  2.667643E+13  2.785618E+21  1.800000E+01  2.300400E+04
+      3  1.268000E+03  1.322000E+03  4.665600E+06  1.142208E+08  2.688658E+13  2.911060E+21  1.800000E+01  2.397600E+04
+      4  1.322000E+03  1.376000E+03  4.665600E+06  1.188864E+08  2.709364E+13  3.037468E+21  1.800000E+01  2.494800E+04
+      5  1.376000E+03  1.430000E+03  4.665600E+06  1.235520E+08  2.729756E+13  3.164827E+21  1.800000E+01  2.592000E+04
+      6  1.430000E+03  1.484000E+03  4.665600E+06  1.282176E+08  2.749836E+13  3.293123E+21  1.800000E+01  2.689200E+04
+      7  1.484000E+03  1.538000E+03  4.665600E+06  1.328832E+08  2.769608E+13  3.422342E+21  1.800000E+01  2.786400E+04
+      8  1.538000E+03  1.592000E+03  4.665600E+06  1.375488E+08  2.789076E+13  3.552469E+21  1.800000E+01  2.883600E+04
+      9  1.592000E+03  1.646000E+03  4.665600E+06  1.422144E+08  2.808248E+13  3.683491E+21  1.800000E+01  2.980800E+04
+     10  1.646000E+03  1.700000E+03  4.665600E+06  1.468800E+08  2.827126E+13  3.815393E+21  1.800000E+01  3.078000E+04
+          
+              step - step index within this case
+                t0 - time at beginning-of-step in input units
+                t1 - time at end-of-step in input units
+                dt - length of step in seconds
+                 t - end-of-step cumulative time in seconds
+              flux - flux in neutrons/cm^2-sec (CALCULATED)
+           fluence - cumulative end-of-step fluence in neutrons/cm^2 (CALCULATED)
+             power - power in mega-watts (INPUT)     
+            energy - cumulative end-of-step energy released in mega-watt-days (INPUT)     
+=========================================================================================================================
+.
+.
+.
+.
+.
+*************************************************************************************************************************
+********************                                                                                 ********************
+********************                                                                                 ********************
+********************                    Library information                                          ********************
+********************                                                                                 ********************
+********************                                                                                 ********************
+*************************************************************************************************************************
+.
+.
+=========================================================================================================================
+=   Library summary for case '5' (#5/6)                                                                                 =
+=   Case 5: Irradiation #3                                                                                              =
+-------------------------------------------------------------------------------------------------------------------------
+filename: /tmp/scale.nsly.28828/InterpLib.f33 cross-section data taken from position number: 3
+library title delimited by {}: 
+{}
+date library was produced: 5/30/2006
+total number of nuclides in library: 1946
+number of light-element nuclides: 698
+number of actinide nuclides: 129
+number of fission product nuclides: 1119
+number of nonzero off-diagonal matrix elements: 35013
+=========================================================================================================================
+.
+.
+*************************************************************************************************************************
+********************                                                                                 ********************
+********************                                                                                 ********************
+********************                    Concentration tables                                         ********************
+********************                                                                                 ********************
+********************                                                                                 ********************
+*************************************************************************************************************************
+.
+.
+=========================================================================================================================
+=   Nuclide concentrations in grams, actinides for case '5' (#5/6)                                                      =
+=   Case 5: Irradiation #3                                                                                              =
+-------------------------------------------------------------------------------------------------------------------------
+  (relative cutoff; integral of concentrations over time >   1.00E-05 % of integral of all concentrations over time)
+.
+                1160.000d     1214.000d     1268.000d     1322.000d     1376.000d     1430.000d     1484.000d     1538.000d     1592.000d     1646.000d     1700.000d   
+  he-4         1.514629E-01  1.749389E-01  2.027043E-01  2.346212E-01  2.705825E-01  3.105159E-01  3.543796E-01  4.021571E-01  4.538525E-01  5.094861E-01  5.690903E-01
+  u-234        3.711255E+02  3.645223E+02  3.579851E+02  3.515237E+02  3.451397E+02  3.388349E+02  3.326107E+02  3.264685E+02  3.204096E+02  3.144350E+02  3.085457E+02
+  u-235        1.059942E+04  1.011936E+04  9.657081E+03  9.212710E+03  8.785777E+03  8.375817E+03  7.982357E+03  7.604927E+03  7.243052E+03  6.896262E+03  6.564084E+03
+  u-236        3.068873E+03  3.140305E+03  3.207809E+03  3.271404E+03  3.331197E+03  3.387294E+03  3.439804E+03  3.488834E+03  3.534492E+03  3.576886E+03  3.616122E+03
+  u-237        7.003613E-02  4.044774E+00  4.169276E+00  4.270968E+00  4.368985E+00  4.463393E+00  4.554201E+00  4.641431E+00  4.725109E+00  4.805271E+00  4.881958E+00
+  u-238        9.560566E+05  9.552288E+05  9.543941E+05  9.535536E+05  9.527073E+05  9.518555E+05  9.509981E+05  9.501354E+05  9.492674E+05  9.483943E+05  9.475161E+05
+  u-239        0.000000E+00  3.233507E-01  3.260523E-01  3.283314E-01  3.305663E-01  3.327565E-01  3.349023E-01  3.370043E-01  3.390632E-01  3.410798E-01  3.430548E-01
+  np-237       2.514115E+02  2.621667E+02  2.768705E+02  2.916522E+02  3.064653E+02  3.212832E+02  3.360804E+02  3.508323E+02  3.655157E+02  3.801081E+02  3.945883E+02
+  np-238       9.970423E-07  4.378224E-01  4.666106E-01  4.953699E-01  5.245129E-01  5.539857E-01  5.837355E-01  6.137109E-01  6.438614E-01  6.741379E-01  7.044922E-01
+  np-239       4.001121E-04  4.669041E+01  4.708013E+01  4.740890E+01  4.773128E+01  4.804721E+01  4.835674E+01  4.865994E+01  4.895692E+01  4.924780E+01  4.953267E+01
+  pu-238       6.040511E+01  6.667147E+01  7.382028E+01  8.143723E+01  8.950219E+01  9.799686E+01  1.069040E+02  1.162073E+02  1.258910E+02  1.359396E+02  1.463378E+02
+  pu-239       4.896737E+03  4.919450E+03  4.980282E+03  5.033250E+03  5.079220E+03  5.119019E+03  5.153381E+03  5.182964E+03  5.208350E+03  5.230058E+03  5.248546E+03
+  pu-240       1.608323E+03  1.695595E+03  1.778749E+03  1.857679E+03  1.932336E+03  2.002719E+03  2.068868E+03  2.130858E+03  2.188793E+03  2.242799E+03  2.293018E+03
+  pu-241       8.681768E+02  8.985346E+02  9.326978E+02  9.697942E+02  1.009085E+03  1.049910E+03  1.091691E+03  1.133918E+03  1.176151E+03  1.218015E+03  1.259191E+03
+  pu-242       2.220882E+02  2.480191E+02  2.746833E+02  3.021483E+02  3.304907E+02  3.597608E+02  3.899855E+02  4.211707E+02  4.533041E+02  4.863579E+02  5.202909E+02
+  am-241       3.666261E+01  3.953120E+01  4.234073E+01  4.511961E+01  4.788460E+01  5.064635E+01  5.341041E+01  5.617824E+01  5.894797E+01  6.171524E+01  6.447377E+01
+  am-242m      5.968658E-01  6.994857E-01  7.810935E-01  8.515132E-01  9.160696E-01  9.776015E-01  1.037622E+00  1.096922E+00  1.155891E+00  1.214687E+00  1.273326E+00
+  am-243       3.133745E+01  3.644463E+01  4.214911E+01  4.841587E+01  5.525160E+01  6.266477E+01  7.066468E+01  7.926071E+01  8.846174E+01  9.827561E+01  1.087087E+02
+  cm-242       4.934375E+00  5.968414E+00  6.994362E+00  7.979488E+00  8.933153E+00  9.863487E+00  1.077732E+01  1.168019E+01  1.257643E+01  1.346924E+01  1.436077E+01
+  cm-243       1.013934E-01  1.167174E-01  1.355337E-01  1.573493E-01  1.817582E-01  2.084233E-01  2.370656E-01  2.674553E-01  2.994026E-01  3.327494E-01  3.673622E-01
+  cm-244       5.341187E+00  6.569310E+00  8.017348E+00  9.692123E+00  1.161583E+01  1.381099E+01  1.630046E+01  1.910746E+01  2.225552E+01  2.576846E+01  2.967032E+01
+  cm-245       1.363915E-01  1.764758E-01  2.248447E-01  2.826147E-01  3.510291E-01  4.314092E-01  5.251480E-01  6.337052E-01  7.586015E-01  9.014141E-01  1.063771E+00
+------------
+  totals       9.780825E+05  9.770847E+05  9.760871E+05  9.750906E+05  9.740951E+05  9.731006E+05  9.721072E+05  9.711147E+05  9.701232E+05  9.691327E+05  9.681431E+05
+=========================================================================================================================
+.
+.
+=========================================================================================================================
+=   History overview for case '6' (#6/6)                                                                                =
+=   Case 6 Decay #3 (5 years)                                                                                           =
+-------------------------------------------------------------------------------------------------------------------------
+   step            t0            t1            dt             t          flux       fluence         power        energy
+    (-)           (d)           (d)           (s)           (s)     (n/cm2-s)       (n/cm2)          (MW)         (MWd)
+      1  1.700000E+03  1.701000E+03  8.640000E+04  1.469664E+08  0.000000E+00  3.815393E+21  0.000000E+00  3.078000E+04
+      2  1.701000E+03  1.703000E+03  1.728000E+05  1.471392E+08  0.000000E+00  3.815393E+21  0.000000E+00  3.078000E+04
+      3  1.703000E+03  1.710000E+03  6.048000E+05  1.477440E+08  0.000000E+00  3.815393E+21  0.000000E+00  3.078000E+04
+      4  1.710000E+03  1.730000E+03  1.728000E+06  1.494720E+08  0.000000E+00  3.815393E+21  0.000000E+00  3.078000E+04
+      5  1.730000E+03  1.800000E+03  6.048000E+06  1.555200E+08  0.000000E+00  3.815393E+21  0.000000E+00  3.078000E+04
+      6  1.800000E+03  2.000000E+03  1.728000E+07  1.728000E+08  0.000000E+00  3.815393E+21  0.000000E+00  3.078000E+04
+      7  2.000000E+03  2.700000E+03  6.048000E+07  2.332800E+08  0.000000E+00  3.815393E+21  0.000000E+00  3.078000E+04
+      8  2.700000E+03  3.525000E+03  7.128000E+07  3.045600E+08  0.000000E+00  3.815393E+21  0.000000E+00  3.078000E+04
+          
+              step - step index within this case
+                t0 - time at beginning-of-step in input units
+                t1 - time at end-of-step in input units
+                dt - length of step in seconds
+                 t - end-of-step cumulative time in seconds
+              flux - flux in neutrons/cm^2-sec (CALCULATED)
+           fluence - cumulative end-of-step fluence in neutrons/cm^2 (CALCULATED)
+             power - power in mega-watts (INPUT)     
+            energy - cumulative end-of-step energy released in mega-watt-days (INPUT)     
+=========================================================================================================================
+.
+.
+.
+.
+.
+*************************************************************************************************************************
+********************                                                                                 ********************
+********************                                                                                 ********************
+********************                    Library information                                          ********************
+********************                                                                                 ********************
+********************                                                                                 ********************
+*************************************************************************************************************************
+.
+.
+=========================================================================================================================
+=   Library summary for case '6' (#6/6)                                                                                 =
+=   Case 6 Decay #3 (5 years)                                                                                           =
+-------------------------------------------------------------------------------------------------------------------------
+filename: /tmp/scale.nsly.28828/InterpLib.f33 cross-section data taken from position number: 3
+library title delimited by {}: 
+{}
+date library was produced: 5/30/2006
+total number of nuclides in library: 1946
+number of light-element nuclides: 698
+number of actinide nuclides: 129
+number of fission product nuclides: 1119
+number of nonzero off-diagonal matrix elements: 35013
+=========================================================================================================================
+.
+.
+*************************************************************************************************************************
+********************                                                                                 ********************
+********************                                                                                 ********************
+********************                    Concentration tables                                         ********************
+********************                                                                                 ********************
+********************                                                                                 ********************
+*************************************************************************************************************************
+.
+.
+=========================================================================================================================
+=   Element concentrations in gram-atoms, actinides for case '6' (#6/6)                                                 =
+=   Case 6 Decay #3 (5 years)                                                                                           =
+-------------------------------------------------------------------------------------------------------------------------
+  (relative cutoff; integral of concentrations over time >   1.00E-06 % of integral of all concentrations over time)
+.
+                1700.000d     1701.000d     1703.000d     1710.000d     1730.000d     1800.000d     2000.000d     2700.000d     3525.000d   
+    he        1.421801E-01  1.424645E-01  1.430312E-01  1.449834E-01  1.502890E-01  1.660816E-01  1.950321E-01  2.347282E-01  2.645052E-01
+     u        4.024897E+03  4.024894E+03  4.024891E+03  4.024883E+03  4.024877E+03  4.024877E+03  4.024881E+03  4.024894E+03  4.024910E+03
+    np        1.874759E+00  1.824192E+00  1.757460E+00  1.688934E+00  1.684309E+00  1.685321E+00  1.685678E+00  1.687821E+00  1.691997E+00
+    pu        3.949594E+01  3.954922E+01  3.961853E+01  3.969168E+01  3.969354E+01  3.965878E+01  3.954537E+01  3.911258E+01  3.863417E+01
+    am        7.205640E-01  7.211692E-01  7.224028E-01  7.272068E-01  7.409597E-01  7.887991E-01  9.229820E-01  1.364658E+00  1.833428E+00
+    cm        1.871422E-01  1.872517E-01  1.868601E-01  1.850586E-01  1.801414E-01  1.657311E-01  1.408848E-01  1.166680E-01  1.066824E-01
+------------
+  totals       4.067318E+03  4.067318E+03  4.067319E+03  4.067321E+03  4.067326E+03  4.067342E+03  4.067371E+03  4.067411E+03  4.067440E+03
+=========================================================================================================================
+.
+.
+=========================================================================================================================
+=   Nuclide concentrations in grams, actinides for case '6' (#6/6)                                                      =
+=   Case 6 Decay #3 (5 years)                                                                                           =
+-------------------------------------------------------------------------------------------------------------------------
+  (relative cutoff; integral of concentrations over time >   1.00E-06 % of integral of all concentrations over time)
+.
+                1700.000d     1701.000d     1703.000d     1710.000d     1730.000d     1800.000d     2000.000d     2700.000d     3525.000d   
+  he-4         5.690903E-01  5.702283E-01  5.724968E-01  5.803105E-01  6.015468E-01  6.647581E-01  7.806354E-01  9.395232E-01  1.058709E+00
+  u-234        3.085457E+02  3.085488E+02  3.085551E+02  3.085770E+02  3.086400E+02  3.088635E+02  3.095197E+02  3.118679E+02  3.146113E+02
+  u-235        6.564084E+03  6.564085E+03  6.564085E+03  6.564088E+03  6.564096E+03  6.564125E+03  6.564207E+03  6.564494E+03  6.564832E+03
+  u-236        3.616122E+03  3.616123E+03  3.616124E+03  3.616129E+03  3.616142E+03  3.616188E+03  3.616318E+03  3.616774E+03  3.617313E+03
+  u-237        4.881958E+00  4.405520E+00  3.587597E+00  1.748348E+00  2.242579E-01  2.070761E-04  3.668145E-05  3.343783E-05  2.998125E-05
+  u-238        9.475161E+05  9.475161E+05  9.475161E+05  9.475161E+05  9.475161E+05  9.475161E+05  9.475161E+05  9.475161E+05  9.475161E+05
+  np-237       3.945883E+02  3.950650E+02  3.958835E+02  3.977248E+02  3.992548E+02  3.995019E+02  3.995867E+02  4.000947E+02  4.010846E+02
+  np-239       4.953267E+01  3.716220E+01  2.062931E+01  2.629277E+00  7.399015E-03  9.360977E-05  9.360496E-05  9.358812E-05  9.356828E-05
+  pu-238       1.463378E+02  1.465914E+02  1.469487E+02  1.475747E+02  1.486469E+02  1.516378E+02  1.562873E+02  1.576677E+02  1.550828E+02
+  pu-239       5.248546E+03  5.261259E+03  5.277791E+03  5.295789E+03  5.298403E+03  5.298385E+03  5.298312E+03  5.298055E+03  5.297752E+03
+  pu-240       2.293018E+03  2.293022E+03  2.293027E+03  2.293043E+03  2.293091E+03  2.293258E+03  2.293726E+03  2.295266E+03  2.296899E+03
+  pu-241       1.259191E+03  1.259025E+03  1.258692E+03  1.257527E+03  1.254205E+03  1.242647E+03  1.210207E+03  1.103192E+03  9.891516E+02
+  pu-242       5.202909E+02  5.203011E+02  5.203061E+02  5.203068E+02  5.203068E+02  5.203068E+02  5.203069E+02  5.203071E+02  5.203073E+02
+  am-241       6.447377E+01  6.464001E+01  6.497244E+01  6.613523E+01  6.945134E+01  8.098649E+01  1.133412E+02  2.198415E+02  3.328783E+02
+  am-242m      1.273326E+00  1.273309E+00  1.273274E+00  1.273154E+00  1.272812E+00  1.271613E+00  1.268195E+00  1.256304E+00  1.242433E+00
+  am-243       1.087087E+02  1.087896E+02  1.087925E+02  1.087923E+02  1.087917E+02  1.087897E+02  1.087842E+02  1.087646E+02  1.087415E+02
+  cm-242       1.436077E+01  1.434888E+01  1.425080E+01  1.383614E+01  1.270807E+01  9.436527E+00  4.032446E+00  2.084643E-01  9.383400E-03
+  cm-243       3.673622E-01  3.673378E-01  3.672888E-01  3.671177E-01  3.666291E-01  3.649242E-01  3.600966E-01  3.436974E-01  3.253259E-01
+  cm-244       2.967032E+01  2.970905E+01  2.971243E+01  2.969100E+01  2.962881E+01  2.941215E+01  2.880182E+01  2.676369E+01  2.454598E+01
+  cm-245       1.063771E+00  1.063771E+00  1.063771E+00  1.063769E+00  1.063764E+00  1.063748E+00  1.063700E+00  1.063534E+00  1.063338E+00
+  cm-246       9.603792E-02  9.603788E-02  9.603780E-02  9.603753E-02  9.603676E-02  9.603407E-02  9.602637E-02  9.599942E-02  9.596766E-02
+------------
+  totals       9.681431E+05  9.681431E+05  9.681431E+05  9.681431E+05  9.681431E+05  9.681431E+05  9.681431E+05  9.681431E+05  9.681431E+05
+=========================================================================================================================
+.
+.
+=========================================================================================================================
+=   Element concentrations in grams, fission products for case '6' (#6/6)                                               =
+=   Case 6 Decay #3 (5 years)                                                                                           =
+-------------------------------------------------------------------------------------------------------------------------
+  (relative cutoff; integral of concentrations over time >   1.00E-06 % of integral of all concentrations over time)
+.
+                1700.000d     1701.000d     1703.000d     1710.000d     1730.000d     1800.000d     2000.000d     2700.000d     3525.000d   
+     h        6.201278E-02  6.200440E-02  6.198765E-02  6.192905E-02  6.176198E-02  6.118126E-02  5.955614E-02  5.424646E-02  4.868054E-02
+    he        1.085905E+00  1.085913E+00  1.085930E+00  1.085989E+00  1.086156E+00  1.086737E+00  1.088362E+00  1.093671E+00  1.099237E+00
+    li        1.120670E-02  1.120670E-02  1.120670E-02  1.120670E-02  1.120670E-02  1.120670E-02  1.120670E-02  1.120670E-02  1.120670E-02
+    be        9.661486E-03  9.661486E-03  9.661486E-03  9.661485E-03  9.661485E-03  9.661485E-03  9.661482E-03  9.661475E-03  9.661466E-03
+     b        6.411841E-04  6.411842E-04  6.411843E-04  6.411843E-04  6.411846E-04  6.411853E-04  6.411874E-04  6.411948E-04  6.412035E-04
+     c        3.121638E-03  3.121637E-03  3.121635E-03  3.121629E-03  3.121610E-03  3.121544E-03  3.121357E-03  3.120703E-03  3.119932E-03
+    ne        3.582342E-03  3.582342E-03  3.582342E-03  3.582342E-03  3.582342E-03  3.582342E-03  3.582342E-03  3.582342E-03  3.582342E-03
+    zn        1.735791E-03  1.732206E-03  1.728125E-03  1.724589E-03  1.724291E-03  1.724290E-03  1.724290E-03  1.724290E-03  1.724290E-03
+    ga        2.771974E-03  2.768024E-03  2.766484E-03  2.764902E-03  2.764757E-03  2.764757E-03  2.764757E-03  2.764757E-03  2.764757E-03
+    ge        3.482324E-01  3.480633E-01  3.480477E-01  3.480518E-01  3.480523E-01  3.480523E-01  3.480523E-01  3.480523E-01  3.480523E-01
+    as        1.078953E-01  1.075145E-01  1.071567E-01  1.068871E-01  1.068729E-01  1.068729E-01  1.068729E-01  1.068729E-01  1.068729E-01
+    se        4.878735E+01  4.878723E+01  4.878761E+01  4.878788E+01  4.878789E+01  4.878789E+01  4.878788E+01  4.878786E+01  4.878784E+01
+    br        1.924672E+01  1.924155E+01  1.924105E+01  1.924074E+01  1.924073E+01  1.924074E+01  1.924074E+01  1.924076E+01  1.924078E+01
+    kr        3.261848E+02  3.261464E+02  3.261391E+02  3.261134E+02  3.260393E+02  3.257820E+02  3.250642E+02  3.227428E+02  3.203517E+02
+    rb        3.086065E+02  3.086217E+02  3.086286E+02  3.086525E+02  3.087229E+02  3.089771E+02  3.096947E+02  3.120161E+02  3.144071E+02
+    sr        7.840481E+02  7.837038E+02  7.832658E+02  7.818876E+02  7.785022E+02  7.709115E+02  7.615557E+02  7.402083E+02  7.165501E+02
+     y        4.127225E+02  4.125445E+02  4.123913E+02  4.119232E+02  4.107169E+02  4.077532E+02  4.050184E+02  4.046234E+02  4.046171E+02
+    zr        3.244334E+03  3.244239E+03  3.243943E+03  3.243259E+03  3.241644E+03  3.238554E+03  3.239988E+03  3.260349E+03  3.284012E+03
+    nb        1.953771E+01  1.951373E+01  1.948449E+01  1.930291E+01  1.807885E+01  1.128516E+01  1.602750E+00  3.088719E-03  2.897135E-03
+    mo        3.059655E+03  3.059894E+03  3.060235E+03  3.062223E+03  3.069507E+03  3.089947E+03  3.110285E+03  3.113266E+03  3.113267E+03
+    tc        7.356114E+02  7.360114E+02  7.365872E+02  7.373144E+02  7.374633E+02  7.374638E+02  7.374625E+02  7.374578E+02  7.374524E+02
+    ru        2.251002E+03  2.250264E+03  2.248940E+03  2.244561E+03  2.233873E+03  2.209512E+03  2.175140E+03  2.126601E+03  2.112481E+03
+    rh        4.381332E+02  4.383868E+02  4.389705E+02  4.416588E+02  4.481612E+02  4.590663E+02  4.634022E+02  4.635328E+02  4.635328E+02
+    pd        1.255740E+03  1.256183E+03  1.256895E+03  1.258582E+03  1.262768E+03  1.276223E+03  1.306259E+03  1.354671E+03  1.368796E+03
+    ag        7.873080E+01  7.877224E+01  7.875965E+01  7.867344E+01  7.857649E+01  7.849049E+01  7.834647E+01  7.818023E+01  7.815527E+01
+    cd        8.043569E+01  8.046207E+01  8.050002E+01  8.058549E+01  8.068004E+01  8.076243E+01  8.090466E+01  8.107066E+01  8.109546E+01
+    in        1.637178E+00  1.639251E+00  1.642574E+00  1.646571E+00  1.648951E+00  1.652562E+00  1.654361E+00  1.654632E+00  1.654834E+00
+    sn        4.771555E+01  4.770496E+01  4.769676E+01  4.767791E+01  4.765056E+01  4.761607E+01  4.757292E+01  4.754610E+01  4.753895E+01
+    sb        1.439805E+01  1.432882E+01  1.427890E+01  1.418612E+01  1.409083E+01  1.381852E+01  1.308318E+01  1.111513E+01  9.733575E+00
+    te        4.429722E+02  4.424162E+02  4.416870E+02  4.406050E+02  4.400765E+02  4.397331E+02  4.400477E+02  4.419057E+02  4.432928E+02
+     i        1.951985E+02  1.942316E+02  1.934109E+02  1.920965E+02  1.910225E+02  1.913558E+02  1.918189E+02  1.919558E+02  1.919573E+02
+    xe        4.902860E+03  4.903472E+03  4.903719E+03  4.903612E+03  4.903721E+03  4.903914E+03  4.903915E+03  4.903915E+03  4.903915E+03
+    cs        2.712605E+03  2.713388E+03  2.714407E+03  2.715859E+03  2.714330E+03  2.704180E+03  2.676937E+03  2.598299E+03  2.526753E+03
+    ba        1.358678E+03  1.358212E+03  1.357448E+03  1.355568E+03  1.354354E+03  1.362461E+03  1.389654E+03  1.468291E+03  1.539837E+03
+    la        1.130034E+03  1.129866E+03  1.129759E+03  1.129343E+03  1.128686E+03  1.128357E+03  1.128350E+03  1.128350E+03  1.128350E+03
+    ce        2.415428E+03  2.414769E+03  2.413465E+03  2.409728E+03  2.397657E+03  2.359541E+03  2.295504E+03  2.216026E+03  2.200715E+03
+    pr        1.019684E+03  1.020015E+03  1.020527E+03  1.021414E+03  1.024759E+03  1.033629E+03  1.036780E+03  1.036823E+03  1.036822E+03
+    nd        3.521602E+03  3.522518E+03  3.524088E+03  3.529244E+03  3.541497E+03  3.572657E+03  3.633591E+03  3.713024E+03  3.728335E+03
+    pm        1.439218E+02  1.437548E+02  1.435681E+02  1.434287E+02  1.424364E+02  1.355195E+02  1.170965E+02  7.056105E+01  3.884510E+01
+    sm        6.571167E+02  6.573757E+02  6.578079E+02  6.589350E+02  6.613957E+02  6.688737E+02  6.872492E+02  7.335954E+02  7.650915E+02
+    eu        1.378029E+02  1.378577E+02  1.378502E+02  1.374527E+02  1.365199E+02  1.355593E+02  1.343501E+02  1.306951E+02  1.272281E+02
+    gd        9.055479E+01  9.066241E+01  9.085779E+01  9.142068E+01  9.237327E+01  9.335298E+01  9.461666E+01  9.846068E+01  1.021474E+02
+    tb        2.344028E+00  2.344901E+00  2.344197E+00  2.339442E+00  2.330152E+00  2.312174E+00  2.296363E+00  2.293642E+00  2.293638E+00
+    dy        1.004252E+00  1.005186E+00  1.006933E+00  1.011887E+00  1.021173E+00  1.039151E+00  1.054962E+00  1.057683E+00  1.057687E+00
+    ho        5.977459E-02  5.977218E-02  5.975518E-02  5.974460E-02  5.974293E-02  5.974288E-02  5.974283E-02  5.974265E-02  5.974244E-02
+    er        2.069404E-02  2.071722E-02  2.074023E-02  2.075918E-02  2.076183E-02  2.076128E-02  2.076134E-02  2.076154E-02  2.076175E-02
+    tm        4.106452E-04  4.108136E-04  4.109402E-04  4.107364E-04  4.078485E-04  3.938911E-04  3.685107E-04  3.375552E-04  3.243516E-04
+    yb        4.120013E-04  4.124206E-04  4.132178E-04  4.155301E-04  4.206856E-04  4.352954E-04  4.606595E-04  4.916049E-04  5.048083E-04
+------------
+  totals       3.186005E+04  3.186005E+04  3.186005E+04  3.186005E+04  3.186005E+04  3.186005E+04  3.186004E+04  3.186004E+04  3.186003E+04
+=========================================================================================================================
+.
+.
+=========================================================================================================================
+=   Element concentrations in curies, fission products for case '6' (#6/6)                                              =
+=   Case 6 Decay #3 (5 years)                                                                                           =
+-------------------------------------------------------------------------------------------------------------------------
+  (relative cutoff; integral of concentrations over time >   1.00E-02 % of integral of all concentrations over time)
+.
+                1700.000d     1701.000d     1703.000d     1710.000d     1730.000d     1800.000d     2000.000d     2700.000d     3525.000d   
+     h        5.233664E+02  5.232859E+02  5.231248E+02  5.225615E+02  5.209554E+02  5.153727E+02  4.997496E+02  4.487054E+02  3.951978E+02
+    br        9.005747E+05  9.419268E+02  3.452899E+02  1.275472E+01  1.029857E-03  5.391329E-18  0.000000E+00  0.000000E+00  0.000000E+00
+    kr        1.806064E+06  1.195658E+04  8.246527E+03  8.234719E+03  8.205615E+03  8.104557E+03  7.822625E+03  6.910889E+03  5.971794E+03
+    rb        2.644118E+06  1.701666E+03  7.531936E+02  5.805290E+02  2.759081E+02  2.044183E+01  1.312726E-02  1.998488E-05  1.886017E-05
+    sr        4.054444E+06  5.334922E+05  4.366413E+05  4.002650E+05  3.200096E+05  1.629287E+05  7.102330E+04  6.177183E+04  5.842956E+04
+     y        6.020614E+06  7.807681E+05  5.745938E+05  5.276170E+05  4.300569E+05  2.245296E+05  7.963465E+04  6.179118E+04  5.844474E+04
+    zr        4.809172E+06  1.055688E+06  7.812914E+05  6.854588E+05  5.519647E+05  2.586792E+05  2.967222E+04  1.678159E+01  1.619608E+00
+    nb        7.297775E+06  1.361951E+06  8.561648E+05  7.666702E+05  7.170468E+05  4.466648E+05  6.330463E+04  3.392109E+01  4.505348E-01
+    mo        4.990387E+06  6.983560E+05  4.216044E+05  7.207823E+04  4.635396E+02  9.911843E-06  2.456633E-08  2.455701E-08  2.454603E-08
+    tc        5.805944E+06  6.715137E+05  4.082203E+05  6.980370E+04  4.614582E+02  1.262732E+01  1.262718E+01  1.262708E+01  1.262698E+01
+    ru        2.724944E+06  1.229242E+06  1.183876E+06  1.085852E+06  8.615794E+05  4.644499E+05  2.246077E+05  5.968756E+04  1.280236E+04
+    rh        3.491372E+06  1.642675E+06  1.349455E+06  1.090842E+06  8.607335E+05  4.642051E+05  2.246015E+05  5.968769E+04  1.280238E+04
+    pd        2.764448E+05  6.394934E+04  6.436368E+03  7.599274E+00  5.289845E-01  1.378565E-01  1.139981E-01  1.139913E-01  1.139912E-01
+    ag        4.017645E+05  9.950836E+04  3.520312E+04  1.585782E+04  4.119606E+03  1.633348E+03  9.358775E+02  1.341782E+02  1.360099E+01
+    sn        7.038632E+05  7.727789E+03  5.566935E+03  3.335209E+03  1.396810E+03  5.800200E+02  2.218170E+02  3.053743E+01  2.223154E+01
+    sb        1.835289E+06  5.414501E+04  3.661412E+04  1.540377E+04  7.091950E+03  6.362760E+03  5.438890E+03  3.335784E+03  1.880124E+03
+    te        3.966544E+06  7.424188E+05  4.811991E+05  1.455508E+05  4.113084E+04  1.623615E+04  3.957080E+03  8.444554E+02  4.591923E+02
+     i        5.921438E+06  1.584936E+06  8.706799E+05  3.046642E+05  4.013866E+04  9.318237E+01  2.597152E-02  2.596873E-02  2.596873E-02
+    xe        4.544700E+06  1.265919E+06  8.272657E+05  3.323483E+05  2.550306E+04  5.387566E+01  5.797582E-04  1.804360E-10  2.713155E-17
+    cs        3.932287E+06  2.394386E+05  2.361540E+05  2.270636E+05  2.127478E+05  1.991383E+05  1.804918E+05  1.357823E+05  1.072852E+05
+    ba        4.721809E+06  8.798286E+05  7.985356E+05  5.746870E+05  2.542303E+05  9.449806E+04  8.972835E+04  8.584167E+04  8.147658E+04
+    la        4.674267E+06  8.541907E+05  7.836913E+05  5.526338E+05  1.869563E+05  4.156059E+03  7.882171E-02  7.314071E-06  7.313880E-06
+    ce        3.719339E+06  1.842078E+06  1.532466E+06  1.266375E+06  1.011351E+06  5.963564E+05  3.106044E+05  5.632953E+04  7.568691E+03
+    pr        3.246432E+06  1.377258E+06  1.292672E+06  1.097601E+06  7.716371E+05  5.148806E+05  3.136369E+05  5.712019E+04  7.674928E+03
+    nd        7.533902E+05  2.965421E+05  2.613577E+05  1.680043E+05  4.753262E+04  5.725874E+02  1.881727E-03  1.417222E-09  1.435413E-09
+    pm        7.872299E+05  4.775884E+05  3.315726E+05  1.872549E+05  1.482187E+05  1.301615E+05  1.087867E+05  6.546049E+04  3.603710E+04
+    sm        2.828460E+05  1.645177E+05  7.925301E+04  6.713656E+03  3.538257E+02  3.485129E+02  3.470452E+02  3.419588E+02  3.360611E+02
+    eu        1.484891E+05  1.261461E+05  1.126859E+05  8.372741E+04  3.835621E+04  9.047354E+03  7.381389E+03  6.095867E+03  4.885884E+03
+------------
+  totals       8.527931E+07  1.807595E+07  1.371881E+07  9.690546E+06  6.542665E+06  3.604488E+06  1.722744E+06  6.616790E+05  3.965009E+05
+=========================================================================================================================
+.
+.
+=========================================================================================================================
+=   Element concentrations in watts, fission products for case '6' (#6/6)                                               =
+=   Case 6 Decay #3 (5 years)                                                                                           =
+-------------------------------------------------------------------------------------------------------------------------
+  (relative cutoff; integral of concentrations over time >   1.00E-02 % of integral of all concentrations over time)
+.
+                1700.000d     1701.000d     1703.000d     1710.000d     1730.000d     1800.000d     2000.000d     2700.000d     3525.000d   
+    as        4.707276E+03  9.813677E-01  4.243009E-01  2.076338E-02  4.848505E-06  6.241689E-08  3.578915E-10  7.914185E-13  6.391576E-16
+    se        7.906237E+03  2.044717E-03  9.183330E-04  6.722832E-05  2.229923E-05  2.226928E-05  2.223986E-05  2.222652E-05  2.222617E-05
+    br        2.332700E+04  1.472844E+01  5.696516E+00  2.104245E-01  1.699034E-05  8.137406E-20  0.000000E+00  0.000000E+00  0.000000E+00
+    kr        2.917624E+04  2.993378E+01  1.236971E+01  1.235042E+01  1.230677E+01  1.215520E+01  1.173236E+01  1.036494E+01  8.956485E+00
+    rb        6.465242E+04  1.796002E+01  3.400004E+00  2.620578E+00  1.245596E+00  9.234784E-02  6.008608E-05  1.244543E-08  9.138031E-09
+    sr        5.880809E+04  2.098408E+03  1.370216E+03  1.232399E+03  9.550939E+02  4.126469E+02  9.687198E+01  7.173698E+01  6.785460E+01
+     y        1.000733E+05  3.528036E+03  2.214994E+03  2.026891E+03  1.675406E+03  9.352182E+02  4.121153E+02  3.421185E+02  3.235971E+02
+    zr        4.827669E+04  5.385285E+03  3.947497E+03  3.455549E+03  2.782567E+03  1.304050E+03  1.495762E+02  7.662714E-02  1.922899E-04
+    nb        1.033500E+05  6.977030E+03  4.143511E+03  3.649264E+03  3.416437E+03  2.131561E+03  3.023777E+02  1.605465E-01  9.910697E-05
+    mo        4.735019E+04  2.796912E+03  1.688523E+03  2.886729E+02  1.856474E+00  3.960081E-08  2.330090E-12  2.329206E-12  2.328164E-12
+    tc        7.121373E+04  6.281602E+02  3.818631E+02  6.529220E+01  4.261904E-01  6.332821E-03  6.332743E-03  6.332687E-03  6.332640E-03
+    ru        1.483481E+04  2.886393E+03  2.687140E+03  2.377048E+03  1.675751E+03  4.996670E+02  2.717320E+01  3.548986E+00  7.612077E-01
+    rh        1.736117E+04  4.461296E+03  4.084692E+03  3.796690E+03  3.607994E+03  3.100639E+03  2.113459E+03  5.721457E+02  1.227193E+02
+    ag        1.558694E+03  2.364738E+02  1.177141E+02  6.578190E+01  3.759207E+01  2.698278E+01  1.548648E+01  2.220180E+00  2.250034E-01
+    sn        9.495274E+03  3.489858E+01  2.959520E+01  1.863336E+01  6.186211E+00  1.672161E+00  5.751421E-01  2.520772E-02  1.029097E-02
+    sb        3.413170E+04  3.376447E+02  2.006231E+02  7.616893E+01  2.652400E+01  2.141034E+01  1.732833E+01  1.055198E+01  5.949973E+00
+    te        3.706720E+04  1.964776E+03  1.106682E+03  2.874649E+02  7.740038E+01  2.399691E+01  3.740134E+00  7.138493E-01  3.865566E-01
+     i        8.781970E+04  1.489550E+04  8.202812E+03  2.162388E+03  1.524368E+02  3.167257E-01  1.215653E-05  1.214619E-05  1.214619E-05
+    xe        4.164932E+04  1.995353E+03  9.278626E+02  3.613947E+02  2.745316E+01  5.206090E-02  6.548462E-07  3.322286E-13  4.995607E-20
+    cs        7.091687E+04  1.619762E+03  1.581134E+03  1.472549E+03  1.303879E+03  1.156549E+03  9.770951E+02  5.586172E+02  3.100476E+02
+    ba        4.110236E+04  2.693839E+03  2.453265E+03  1.790573E+03  8.415116E+02  3.678089E+02  3.525529E+02  3.372818E+02  3.201309E+02
+    la        6.958812E+04  1.420824E+04  1.315678E+04  9.277757E+03  3.138669E+03  6.977298E+01  1.323157E-03  1.322741E-09  1.322706E-09
+    ce        1.721390E+04  3.361680E+03  2.159311E+03  1.359380E+03  9.975189E+02  4.657097E+02  2.043365E+02  3.686528E+01  4.953386E+00
+    pr        2.664101E+04  6.173894E+03  5.895106E+03  5.464148E+03  4.692787E+03  3.703866E+03  2.271467E+03  4.136843E+02  5.558450E+01
+    nd        3.612091E+03  7.177920E+02  6.325968E+02  4.066418E+02  1.150492E+02  1.385905E+00  4.554591E-06  1.604662E-11  1.625259E-11
+    pm        3.867489E+03  1.545056E+03  1.065849E+03  5.110828E+02  2.492445E+02  1.040868E+02  4.189975E+01  2.403299E+01  1.323073E+01
+    sm        6.920516E+02  3.257909E+02  1.566413E+02  1.267276E+01  5.057343E-02  4.099084E-02  4.081780E-02  4.021894E-02  3.952514E-02
+    eu        1.405483E+03  1.214606E+03  1.101183E+03  8.130109E+02  3.573286E+02  6.354989E+01  4.875906E+01  4.159882E+01  3.452110E+01
+------------
+  totals       1.042750E+06  8.030580E+04  5.935573E+04  4.099319E+04  2.615689E+04  1.440527E+04  7.046891E+03  2.425806E+03  1.268989E+03
+=========================================================================================================================
+.
+.
+=========================================================================================================================
+=   Element concentrations in gamma watts, fission products for case '6' (#6/6)                                         =
+=   Case 6 Decay #3 (5 years)                                                                                           =
+-------------------------------------------------------------------------------------------------------------------------
+  (relative cutoff; integral of concentrations over time >   1.00E-02 % of integral of all concentrations over time)
+.
+                1700.000d     1701.000d     1703.000d     1710.000d     1730.000d     1800.000d     2000.000d     2700.000d     3525.000d   
+    as        2.191096E+03  4.661067E-02  1.698363E-02  7.084665E-04  8.312886E-07  4.634261E-08  9.128187E-11  1.722127E-13  1.390807E-16
+    se        4.469940E+03  1.110165E-03  4.919937E-04  2.473601E-05  6.666458E-08  4.133581E-08  1.299476E-08  2.263678E-10  1.913208E-12
+    br        1.354973E+04  1.386491E+01  5.402006E+00  1.995456E-01  1.611194E-05  7.720068E-20  0.000000E+00  0.000000E+00  0.000000E+00
+    kr        1.519850E+04  1.183820E+01  1.105351E-01  1.088442E-01  1.084595E-01  1.071238E-01  1.033973E-01  9.134620E-02  7.893351E-02
+    rb        3.010992E+04  3.811355E+00  4.178245E-01  3.222151E-01  1.534651E-01  1.155445E-02  1.192373E-05  3.278681E-09  4.308854E-12
+    sr        3.382509E+04  3.776713E+02  1.117501E+01  5.678078E-05  1.884260E-06  8.915632E-07  1.051025E-07  5.911890E-11  8.739823E-15
+     y        4.188732E+04  2.790734E+02  1.867060E+01  1.002514E+01  7.906533E+00  3.445707E+00  3.226075E-01  7.201008E-04  5.890353E-04
+    zr        1.902294E+04  3.620353E+03  3.256230E+03  2.974392E+03  2.395234E+03  1.122526E+03  1.287550E+02  6.580381E-02  8.688957E-06
+    nb        4.298859E+04  5.902634E+03  3.811980E+03  3.440624E+03  3.222154E+03  2.011282E+03  2.853921E+02  1.514851E-01  2.616220E-05
+    mo        2.377219E+04  1.124359E+03  6.787864E+02  1.160465E+02  7.463024E-01  1.592019E-08  1.601937E-12  1.601329E-12  1.600613E-12
+    tc        3.666519E+04  5.039678E+02  3.063637E+02  5.237885E+01  3.368518E-01  9.811213E-08  8.509140E-08  8.348967E-08  8.348178E-08
+    ru        8.035661E+03  2.499088E+03  2.348329E+03  2.075288E+03  1.457892E+03  4.236322E+02  1.240100E+01  5.322233E-05  2.513468E-11
+    rh        5.379540E+03  6.737212E+02  5.526180E+02  4.722336E+02  4.503760E+02  3.923266E+02  2.691778E+02  7.289156E+01  1.563445E+01
+    ag        3.539692E+02  7.580402E+01  4.535667E+01  3.570581E+01  3.205111E+01  2.611759E+01  1.499361E+01  2.149517E+00  2.178409E-01
+    in        8.621170E+02  3.822321E+00  2.014361E+00  2.277721E-01  4.802541E-04  1.050593E-05  5.591167E-07  2.299158E-11  7.020049E-16
+    sn        5.907340E+03  8.649371E+00  7.393503E+00  4.487543E+00  1.094128E+00  3.147142E-02  9.501277E-03  1.210617E-03  7.887412E-04
+    sb        2.361315E+04  2.416167E+02  1.403183E+02  5.565901E+01  2.150547E+01  1.744399E+01  1.410319E+01  8.586617E+00  4.841499E+00
+    te        2.214565E+04  1.328996E+03  7.008631E+02  1.307185E+02  9.313832E+00  2.319838E+00  4.256869E-01  1.733665E-01  9.688027E-02
+     i        5.858293E+04  1.135865E+04  6.395881E+03  1.658543E+03  1.046365E+02  2.109684E-01  3.794142E-06  3.787182E-06  3.787182E-06
+    xe        1.674178E+04  6.882605E+02  2.421873E+02  9.188200E+01  6.754709E+00  6.784566E-03  2.401368E-07  2.995041E-13  4.503540E-20
+    cs        3.513199E+04  1.378274E+03  1.342279E+03  1.241043E+03  1.084133E+03  9.489926E+02  7.879035E+02  4.136936E+02  1.936072E+02
+    ba        1.737103E+04  1.210009E+03  1.118850E+03  8.675998E+02  5.074605E+02  3.267612E+02  3.186020E+02  3.048016E+02  2.893023E+02
+    la        4.000271E+04  1.147927E+04  1.068066E+04  7.531683E+03  2.547972E+03  5.664171E+01  1.074139E-03  1.104793E-09  1.104764E-09
+    ce        8.115340E+03  1.136202E+03  6.674320E+02  3.666922E+02  2.555121E+02  9.898811E+01  3.543091E+01  6.344515E+00  8.524777E-01
+    pr        8.325469E+03  1.182184E+02  1.106356E+02  1.079838E+02  1.028535E+02  8.674714E+01  5.332492E+01  9.711649E+00  1.304901E+00
+    nd        1.624761E+03  2.461362E+02  2.169174E+02  1.394375E+02  3.945035E+01  4.752269E-01  1.561764E-06  1.004885E-25  0.000000E+00
+    pm        1.504190E+03  6.436343E+02  4.969951E+02  3.155272E+02  1.758559E+02  5.252455E+01  1.832697E+00  2.511027E-03  1.536230E-03
+    eu        9.831712E+02  8.806010E+02  8.027864E+02  5.942162E+02  2.635110E+02  5.025699E+01  3.935955E+01  3.363574E+01  2.796095E+01
+    tb        6.048351E+00  4.037062E+00  3.941421E+00  3.643703E+00  2.975368E+00  1.517620E+00  2.230646E-01  2.717614E-04  2.960501E-07
+------------
+  totals       5.196384E+05  4.588235E+04  3.399756E+04  2.228942E+04  1.269002E+04  5.622378E+03  1.962363E+03  8.523017E+02  5.339004E+02
+=========================================================================================================================
+.
+.
+=========================================================================================================================
+=   Element concentrations in m3 air, fission products for case '6' (#6/6)                                              =
+=   Case 6 Decay #3 (5 years)                                                                                           =
+-------------------------------------------------------------------------------------------------------------------------
+  (relative cutoff; integral of concentrations over time >   1.00E-02 % of integral of all concentrations over time)
+.
+                1700.000d     1701.000d     1703.000d     1710.000d     1730.000d     1800.000d     2000.000d     2700.000d     3525.000d   
+    sr        8.370683E+15  8.167257E+15  8.096769E+15  7.933535E+15  7.545045E+15  6.772203E+15  6.256275E+15  5.939560E+15  5.618226E+15
+     y        3.064804E+15  2.836628E+15  2.742087E+15  2.527034E+15  2.006321E+15  9.087071E+14  1.378238E+14  5.568428E+13  5.265292E+13
+    zr        3.142337E+15  2.835683E+15  2.635833E+15  2.422007E+15  1.950424E+15  9.140792E+14  1.048674E+14  7.783496E+10  2.425904E+10
+    nb        8.831255E+14  8.405270E+14  8.324836E+14  8.234244E+14  7.707726E+14  4.806834E+14  6.817129E+13  3.653721E+10  4.901397E+08
+    ru        1.683178E+16  1.671113E+16  1.660107E+16  1.623697E+16  1.531034E+16  1.291104E+16  8.718336E+15  2.359191E+15  5.060221E+14
+    ag        5.233037E+13  4.843792E+13  4.220914E+13  2.887715E+13  1.623195E+13  1.157332E+13  6.642291E+12  9.522537E+11  9.650561E+10
+    sb        1.464977E+14  9.891247E+13  8.346005E+13  5.911931E+13  4.885000E+13  4.550895E+13  3.909889E+13  2.399440E+13  1.352203E+13
+    te        2.618692E+15  2.003889E+15  1.339257E+15  4.142528E+14  1.198550E+14  4.753469E+13  1.126002E+13  2.141762E+12  1.156733E+12
+     i        9.104743E+15  6.808352E+15  5.035730E+15  2.632929E+15  4.668496E+14  1.118478E+12  1.492475E+09  1.492456E+09  1.492456E+09
+    cs        3.695911E+15  3.667659E+15  3.659850E+15  3.636213E+15  3.588512E+15  3.485867E+15  3.250141E+15  2.667017E+15  2.272494E+15
+    ba        2.943264E+15  2.734935E+15  2.453149E+15  1.676680E+15  5.652526E+14  1.257543E+13  4.383346E+08  1.761586E+08  1.518065E+08
+    la        6.851785E+14  5.550720E+14  5.155849E+14  3.635748E+14  1.229975E+14  2.734250E+12  5.188969E+07  3.810786E+04  3.810687E+04
+    ce        2.250793E+16  2.229183E+16  2.198356E+16  2.133285E+16  1.988359E+16  1.618536E+16  9.821882E+15  1.788239E+15  2.402759E+14
+    pr        1.064582E+15  9.992443E+14  9.346271E+14  6.722154E+14  2.462881E+14  1.214924E+13  3.340489E+12  6.083323E+11  8.173828E+10
+    nd        4.650893E+14  4.266620E+14  3.760542E+14  2.417327E+14  6.839225E+13  8.238668E+11  2.707519E+06  1.417397E-09  1.435413E-09
+    pm        7.254442E+14  6.706514E+14  5.967989E+14  5.008213E+14  4.469315E+14  3.923397E+14  3.267398E+14  1.965798E+14  1.082208E+14
+    eu        4.312892E+14  4.195101E+14  3.986248E+14  3.400912E+14  2.467327E+14  1.842705E+14  1.735358E+14  1.477431E+14  1.223373E+14
+------------
+  totals       7.784468E+16  7.273715E+16  6.867150E+16  6.190530E+16  5.341299E+16  4.237360E+16  2.892025E+16  1.318292E+16  8.936152E+15
+=========================================================================================================================
+.
+.
+=========================================================================================================================
+=   Element concentrations in m3 water, fission products for case '6' (#6/6)                                            =
+=   Case 6 Decay #3 (5 years)                                                                                           =
+-------------------------------------------------------------------------------------------------------------------------
+  (relative cutoff; integral of concentrations over time >   1.00E-02 % of integral of all concentrations over time)
+.
+                1700.000d     1701.000d     1703.000d     1710.000d     1730.000d     1800.000d     2000.000d     2700.000d     3525.000d   
+    sr        1.844077E+11  1.561890E+11  1.517140E+11  1.468439E+11  1.354500E+11  1.129619E+11  9.884747E+10  9.345150E+10  8.839570E+10
+     y        1.390000E+11  8.508418E+10  7.508549E+10  6.950638E+10  5.685014E+10  3.018973E+10  1.138341E+10  9.020550E+09  8.532080E+09
+    zr        1.303268E+11  7.281295E+10  4.267401E+10  3.515440E+10  2.830590E+10  1.326561E+10  1.521666E+09  8.739263E+05  9.638874E+04
+    nb        3.220227E+10  2.542717E+10  2.442166E+10  2.402272E+10  2.247117E+10  1.399885E+10  1.984101E+09  1.055062E+06  3.046661E+03
+    mo        3.105837E+10  2.267389E+10  1.368845E+10  2.340202E+09  1.504999E+07  3.251308E-01  4.114964E-03  4.113402E-03  4.111563E-03
+    ru        1.882311E+11  1.788246E+11  1.769314E+11  1.713683E+11  1.577983E+11  1.269488E+11  8.364491E+10  2.260892E+10  4.849378E+09
+    ag        3.131355E+09  2.743492E+09  2.214848E+09  1.281328E+09  4.461664E+08  2.435281E+08  1.396791E+08  2.002469E+07  2.029384E+06
+    sb        1.167349E+10  4.474712E+09  3.167642E+09  1.220388E+09  4.537473E+08  3.883283E+08  3.246747E+08  1.985345E+08  1.118878E+08
+    te        1.769279E+11  1.285285E+11  8.377472E+10  2.207017E+10  3.680325E+09  1.249667E+09  2.426294E+08  4.025198E+07  2.156152E+07
+     i        8.879891E+11  6.707902E+11  4.978385E+11  2.608620E+11  4.629302E+10  1.109235E+08  1.545776E+05  1.545758E+05  1.545758E+05
+    cs        1.935137E+11  1.886025E+11  1.878955E+11  1.857761E+11  1.816301E+11  1.732814E+11  1.546681E+11  1.100924E+11  8.232517E+10
+    ba        1.262766E+11  1.102441E+11  9.888451E+10  6.758536E+10  2.278485E+10  5.069882E+08  1.020532E+05  8.823222E+04  8.353656E+04
+    la        1.175773E+11  9.126825E+10  8.472315E+10  5.974419E+10  2.021149E+10  4.493037E+08  8.520507E+03  3.208819E-02  3.208735E-02
+    ce        2.525071E+11  2.350402E+11  2.166035E+11  2.005532E+11  1.834681E+11  1.449056E+11  8.693087E+10  1.582290E+10  2.126037E+09
+    pr        5.965034E+10  4.774111E+10  4.371985E+10  3.172484E+10  1.243661E+10  1.662991E+09  8.359790E+08  1.522483E+08  2.045677E+07
+    nd        2.016240E+10  1.765065E+10  1.555700E+10  1.000025E+10  2.829322E+09  3.408258E+07  1.120075E+02  1.417222E-09  1.435413E-09
+    pm        3.390873E+10  2.719276E+10  1.837842E+10  7.734829E+09  3.511980E+09  2.200500E+09  1.540876E+09  9.193952E+08  5.061437E+08
+    eu        1.522284E+10  1.434116E+10  1.304842E+10  9.644374E+09  4.251775E+09  7.746656E+08  5.979842E+08  5.083882E+08  4.203604E+08
+------------
+  totals       2.642306E+12  2.098822E+12  1.758785E+12  1.308734E+12  8.832805E+11  6.232971E+11  4.426919E+11  2.528422E+11  1.873153E+11
+=========================================================================================================================
+.
+.
+*************************************************************************************************************************
+********************                                                                                 ********************
+********************                                                                                 ********************
+********************                    NEUTRON SOURCES AND SPECTRA                                  ********************
+********************                                                                                 ********************
+********************                                                                                 ********************
+*************************************************************************************************************************
+.
+.
+.
+        neutron source types
+                 alpha decay  81
+         spontaneous fission  33
+             delayed neutron   0
+            ----------------
+                      total: 114
+=========================================================================================================================
+.
+.
+=========================================================================================================================
+=   Elemental constituents for the (a,n) source matrix for case '6' (#6/6)                                              =
+=   Case 6 Decay #3 (5 years)                                                                                           =
+-------------------------------------------------------------------------------------------------------------------------
+  z-value  atom fraction
+  -------  -------------
+      8         0.666667
+     92         0.333333
+  total         1.000000
+=========================================================================================================================
+.
+.
+=========================================================================================================================
+=   Target nuclides for (a,n) reactions for case '6' (#6/6)                                                             =
+=   Case 6 Decay #3 (5 years)                                                                                           =
+-------------------------------------------------------------------------------------------------------------------------
+number of target nuclides to be used:   2
+number of alpha energy groups used:   200
+.
+             nuclide   zaid     atom fraction
+             -------   ----     -------------
+             o-17      80170     0.000253330
+             o-18      80180     0.001333300
+=========================================================================================================================
+.
+.
+=========================================================================================================================
+=   Neutron sources for case '6' (#6/6)                                                                                 =
+=   Case 6 Decay #3 (5 years)                                                                                           =
+-------------------------------------------------------------------------------------------------------------------------
+(a,n) source :: uranium dioxide matrix
+.
+ number of source nuclides to be evaluated:  81
+=========================================================================================================================
+=   (alpha,n) neutron source, neutrons/sec for case '6' (#6/6)                                                          =
+=   Case 6 Decay #3 (5 years)                                                                                           =
+-------------------------------------------------------------------------------------------------------------------------
+                        1700.0d     1701.0d     1703.0d     1710.0d     1730.0d     1800.0d     2000.0d     2700.0d     3525.0d   
+u-234                  9.3122E+02  9.3123E+02  9.3125E+02  9.3132E+02  9.3151E+02  9.3218E+02  9.3416E+02  9.4125E+02  9.4953E+02
+u-236                  8.6108E+01  8.6108E+01  8.6108E+01  8.6108E+01  8.6109E+01  8.6110E+01  8.6113E+01  8.6124E+01  8.6137E+01
+u-238                  7.9532E+01  7.9532E+01  7.9532E+01  7.9532E+01  7.9532E+01  7.9532E+01  7.9532E+01  7.9532E+01  7.9532E+01
+np-237                 1.2907E+02  1.2923E+02  1.2949E+02  1.3010E+02  1.3060E+02  1.3068E+02  1.3071E+02  1.3087E+02  1.3120E+02
+pu-236                 2.2677E+02  2.2701E+02  2.2698E+02  2.2602E+02  2.2308E+02  2.1309E+02  1.8695E+02  1.1825E+02  6.8920E+01
+pu-238                 1.9956E+06  1.9991E+06  2.0040E+06  2.0125E+06  2.0271E+06  2.0679E+06  2.1313E+06  2.1501E+06  2.1149E+06
+pu-239                 2.0237E+05  2.0286E+05  2.0350E+05  2.0419E+05  2.0429E+05  2.0429E+05  2.0429E+05  2.0428E+05  2.0427E+05
+pu-240                 3.2620E+05  3.2620E+05  3.2620E+05  3.2621E+05  3.2621E+05  3.2624E+05  3.2630E+05  3.2652E+05  3.2676E+05
+pu-241                 1.6886E+03  1.6884E+03  1.6880E+03  1.6864E+03  1.6819E+03  1.6664E+03  1.6229E+03  1.4794E+03  1.3265E+03
+pu-242                 1.0830E+03  1.0830E+03  1.0830E+03  1.0830E+03  1.0830E+03  1.0830E+03  1.0830E+03  1.0830E+03  1.0830E+03
+am-241                 1.7448E+05  1.7493E+05  1.7583E+05  1.7897E+05  1.8795E+05  2.1916E+05  3.0672E+05  5.9493E+05  9.0083E+05
+am-243                 1.4740E+04  1.4751E+04  1.4752E+04  1.4752E+04  1.4751E+04  1.4751E+04  1.4750E+04  1.4748E+04  1.4745E+04
+cm-242                 5.3979E+07  5.3934E+07  5.3566E+07  5.2007E+07  4.7767E+07  3.5470E+07  1.5157E+07  7.8357E+05  3.5270E+04
+cm-243                 1.8397E+04  1.8396E+04  1.8394E+04  1.8385E+04  1.8361E+04  1.8275E+04  1.8034E+04  1.7212E+04  1.6292E+04
+cm-244                 2.3209E+06  2.3239E+06  2.3241E+06  2.3225E+06  2.3176E+06  2.3007E+06  2.2529E+06  2.0935E+06  1.9200E+06
+cm-245                 1.3269E+02  1.3269E+02  1.3269E+02  1.3269E+02  1.3269E+02  1.3269E+02  1.3268E+02  1.3266E+02  1.3264E+02
+--------------------
+               total   5.9036E+07  5.8999E+07  5.8637E+07  5.7089E+07  5.2868E+07  4.0625E+07  2.0416E+07  6.1890E+06  5.5369E+06
+=========================================================================================================================
+.
+.
+=========================================================================================================================
+=   Spontaneous fission neutron source, neutrons/sec for case '6' (#6/6)                                                =
+=   Case 6 Decay #3 (5 years)                                                                                           =
+-------------------------------------------------------------------------------------------------------------------------
+                        1700.0d     1701.0d     1703.0d     1710.0d     1730.0d     1800.0d     2000.0d     2700.0d     3525.0d   
+th-230                 2.4498E-07  2.4512E-07  2.4541E-07  2.4643E-07  2.4934E-07  2.5951E-07  2.8863E-07  3.9103E-07  5.1271E-07
+th-232                 4.9746E-11  4.9791E-11  4.9881E-11  5.0196E-11  5.1097E-11  5.4248E-11  6.3251E-11  9.4765E-11  1.3191E-10
+pa-231                 4.8728E-07  4.8787E-07  4.8835E-07  4.8859E-07  4.8878E-07  4.8943E-07  4.9130E-07  4.9786E-07  5.0558E-07
+u-233                  1.0888E-06  1.0890E-06  1.0892E-06  1.0901E-06  1.0927E-06  1.1019E-06  1.1281E-06  1.2200E-06  1.3284E-06
+u-234                  2.1067E+00  2.1067E+00  2.1068E+00  2.1069E+00  2.1073E+00  2.1089E+00  2.1133E+00  2.1294E+00  2.1481E+00
+u-235                  6.8339E-02  6.8339E-02  6.8339E-02  6.8339E-02  6.8339E-02  6.8339E-02  6.8340E-02  6.8343E-02  6.8346E-02
+u-236                  1.5534E+01  1.5534E+01  1.5534E+01  1.5534E+01  1.5534E+01  1.5534E+01  1.5535E+01  1.5537E+01  1.5539E+01
+u-238                  1.2908E+04  1.2908E+04  1.2908E+04  1.2908E+04  1.2908E+04  1.2908E+04  1.2908E+04  1.2908E+04  1.2908E+04
+np-237                 4.4296E-02  4.4349E-02  4.4441E-02  4.4648E-02  4.4820E-02  4.4847E-02  4.4857E-02  4.4914E-02  4.5025E-02
+pu-236                 2.6111E+01  2.6138E+01  2.6135E+01  2.6025E+01  2.5686E+01  2.4536E+01  2.1526E+01  1.3616E+01  7.9356E+00
+pu-238                 3.8074E+05  3.8140E+05  3.8233E+05  3.8396E+05  3.8675E+05  3.9453E+05  4.0662E+05  4.1022E+05  4.0349E+05
+pu-239                 7.8060E+01  7.8249E+01  7.8495E+01  7.8763E+01  7.8802E+01  7.8801E+01  7.8800E+01  7.8796E+01  7.8792E+01
+pu-240                 2.3912E+06  2.3912E+06  2.3912E+06  2.3912E+06  2.3913E+06  2.3915E+06  2.3920E+06  2.3936E+06  2.3953E+06
+pu-241                 2.6004E+00  2.6000E+00  2.5994E+00  2.5969E+00  2.5901E+00  2.5662E+00  2.4992E+00  2.2782E+00  2.0427E+00
+pu-242                 9.0644E+05  9.0646E+05  9.0646E+05  9.0647E+05  9.0647E+05  9.0647E+05  9.0647E+05  9.0647E+05  9.0647E+05
+pu-244                 1.5617E+01  1.5617E+01  1.5617E+01  1.5617E+01  1.5617E+01  1.5617E+01  1.5617E+01  1.5617E+01  1.5617E+01
+am-241                 7.9837E+01  8.0043E+01  8.0454E+01  8.1894E+01  8.6001E+01  1.0028E+02  1.4035E+02  2.7223E+02  4.1220E+02
+am-242m                5.4269E+01  5.4268E+01  5.4266E+01  5.4261E+01  5.4247E+01  5.4196E+01  5.4050E+01  5.3543E+01  5.2952E+01
+am-243                 7.1868E+01  7.1921E+01  7.1923E+01  7.1923E+01  7.1923E+01  7.1921E+01  7.1918E+01  7.1905E+01  7.1889E+01
+cm-242                 2.8234E+08  2.8211E+08  2.8018E+08  2.7203E+08  2.4985E+08  1.8553E+08  7.9280E+07  4.0985E+06  1.8448E+05
+cm-243                 9.9636E+01  9.9629E+01  9.9616E+01  9.9569E+01  9.9437E+01  9.8974E+01  9.7665E+01  9.3217E+01  8.8235E+01
+cm-244                 3.2764E+08  3.2807E+08  3.2811E+08  3.2787E+08  3.2718E+08  3.2479E+08  3.1805E+08  2.9555E+08  2.7106E+08
+cm-245                 1.1828E+02  1.1828E+02  1.1828E+02  1.1828E+02  1.1828E+02  1.1827E+02  1.1827E+02  1.1825E+02  1.1823E+02
+cm-246                 9.1262E+05  9.1262E+05  9.1262E+05  9.1262E+05  9.1261E+05  9.1258E+05  9.1251E+05  9.1225E+05  9.1195E+05
+cm-248                 1.9172E+03  1.9172E+03  1.9172E+03  1.9172E+03  1.9173E+03  1.9173E+03  1.9174E+03  1.9177E+03  1.9179E+03
+bk-249                 4.2221E-02  4.2161E-02  4.1979E-02  4.1347E-02  3.9596E-02  3.4027E-02  2.2065E-02  4.8444E-03  8.1134E-04
+cf-249                 2.3628E-04  2.3856E-04  2.4311E-04  2.5887E-04  3.0262E-04  4.4160E-04  7.3971E-04  1.1660E-03  1.2612E-03
+cf-250                 1.0552E+03  1.0580E+03  1.0578E+03  1.0567E+03  1.0536E+03  1.0430E+03  1.0132E+03  9.1534E+02  8.1209E+02
+cf-252                 5.7343E+04  5.7302E+04  5.7220E+04  5.6933E+04  5.6122E+04  5.3373E+04  4.6239E+04  2.7982E+04  1.5482E+04
+cf-254                 9.3510E+02  9.2445E+02  9.0351E+02  8.3388E+02  6.6311E+02  2.9736E+02  3.0070E+01  9.8882E-03  7.7648E-07
+es-253                 6.7657E-03  6.8261E-03  6.9090E-03  6.8812E-03  5.4359E-03  1.0162E-03  2.0376E-06  1.2875E-16  9.6038E-29
+es-254                 3.1835E-05  3.1755E-05  3.1596E-05  3.1044E-05  2.9522E-05  2.4758E-05  1.4974E-05  2.5763E-06  3.2373E-07
+es-255                 7.2542E-03  7.1264E-03  6.8776E-03  6.0730E-03  4.2563E-03  1.2266E-03  3.5072E-05  1.3862E-10  5.9405E-17
+--------------------
+               total   6.1465E+08  6.1484E+08  6.1295E+08  6.0456E+08  5.8170E+08  5.1499E+08  4.0201E+08  3.0431E+08  2.7589E+08
+=========================================================================================================================
+.
+.
+=========================================================================================================================
+=   Delayed neutron source, neutrons/sec for case '6' (#6/6)                                                            =
+=   Case 6 Decay #3 (5 years)                                                                                           =
+-------------------------------------------------------------------------------------------------------------------------
+.
+   --- all entries are zero in this table ---
+.
+=========================================================================================================================
+.
+.
+=========================================================================================================================
+=   Total neutron source for case '6' (#6/6)                                                                            =
+=   Case 6 Decay #3 (5 years)                                                                                           =
+-------------------------------------------------------------------------------------------------------------------------
+                        1700.0d     1701.0d     1703.0d     1710.0d     1730.0d     1800.0d     2000.0d     2700.0d     3525.0d   
+total(a,n)             5.9036E+07  5.8999E+07  5.8637E+07  5.7089E+07  5.2868E+07  4.0625E+07  2.0416E+07  6.1890E+06  5.5369E+06
+total(SF)              6.1465E+08  6.1484E+08  6.1295E+08  6.0456E+08  5.8170E+08  5.1499E+08  4.0201E+08  3.0431E+08  2.7589E+08
+grand total            6.7368E+08  6.7384E+08  6.7159E+08  6.6165E+08  6.3457E+08  5.5562E+08  4.2243E+08  3.1050E+08  2.8143E+08
+=========================================================================================================================
+.
+.
+=========================================================================================================================
+=   alpha-n neutron source spectrum as a function of time for case '6' (#6/6)                                           =
+=   Case 6 Decay #3 (5 years)                                                                                           =
+-------------------------------------------------------------------------------------------------------------------------
+                                   (neutron spectra for uranium dioxide matrix)
+     boundaries (MeV)      1700.0d     1701.0d     1703.0d     1710.0d     1730.0d     1800.0d     2000.0d     2700.0d     3525.0d   
+ 2.000E+01 - 6.376E+00    4.9423E+01  4.9382E+01  4.9045E+01  4.7618E+01  4.3735E+01  3.2476E+01  1.3878E+01  7.1744E-01  3.2293E-02
+ 6.376E+00 - 3.012E+00    2.0511E+07  2.0498E+07  2.0368E+07  1.9818E+07  1.8318E+07  1.3968E+07  6.7845E+06  1.7127E+06  1.4615E+06
+ 3.012E+00 - 1.827E+00    2.4562E+07  2.4548E+07  2.4400E+07  2.3766E+07  2.2037E+07  1.7024E+07  8.7492E+06  2.9377E+06  2.6882E+06
+ 1.827E+00 - 1.423E+00    5.1633E+06  5.1601E+06  5.1288E+06  4.9947E+06  4.6290E+06  3.5685E+06  1.8180E+06  5.8724E+05  5.3276E+05
+ 1.423E+00 - 9.072E-01    4.2163E+06  4.2136E+06  4.1879E+06  4.0776E+06  3.7770E+06  2.9050E+06  1.4655E+06  4.5176E+05  4.0484E+05
+ 9.072E-01 - 4.076E-01    2.9200E+06  2.9181E+06  2.9003E+06  2.8238E+06  2.6154E+06  2.0111E+06  1.0134E+06  3.1126E+05  2.7927E+05
+ 4.076E-01 - 1.111E-01    1.3908E+06  1.3900E+06  1.3815E+06  1.3453E+06  1.2466E+06  9.6023E+05  4.8753E+05  1.5485E+05  1.3969E+05
+ 1.111E-01 - 1.503E-02    2.5685E+05  2.5669E+05  2.5516E+05  2.4855E+05  2.3054E+05  1.7830E+05  9.2083E+04  3.1485E+04  2.8828E+04
+ 1.503E-02 - 3.035E-03    1.1264E+04  1.1257E+04  1.1191E+04  1.0904E+04  1.0122E+04  7.8528E+03  4.1090E+03  1.4843E+03  1.3774E+03
+ 3.035E-03 - 5.830E-04    8.8930E+02  8.8880E+02  8.8356E+02  8.6102E+02  7.9948E+02  6.2104E+02  3.2658E+02  1.2012E+02  1.1168E+02
+ 5.830E-04 - 1.013E-04    8.9228E+01  8.9175E+01  8.8636E+01  8.6329E+01  8.0034E+01  6.1781E+01  3.1666E+01  1.0582E+01  9.7640E+00
+ 1.013E-04 - 2.902E-05    6.4207E+00  6.4169E+00  6.3782E+00  6.2124E+00  5.7602E+00  4.4491E+00  2.2873E+00  7.8175E-01  7.3363E-01
+ 2.902E-05 - 1.068E-05    3.3753E-01  3.3735E-01  3.3536E-01  3.2680E-01  3.0342E-01  2.3558E-01  1.2324E-01  4.2075E-02  3.5638E-02
+ 1.068E-05 - 3.059E-06    6.5011E-02  6.4970E-02  6.4566E-02  6.2818E-02  5.8029E-02  4.4135E-02  2.1183E-02  4.9405E-03  4.0917E-03
+ 3.059E-06 - 1.855E-06    1.0254E-02  1.0247E-02  1.0183E-02  9.9071E-03  9.1505E-03  6.9554E-03  3.3293E-03  7.6349E-04  6.2987E-04
+ 1.855E-06 - 1.300E-06    4.7284E-03  4.7254E-03  4.6959E-03  4.5685E-03  4.2193E-03  3.2064E-03  1.5332E-03  3.4915E-04  2.8749E-04
+ 1.300E-06 - 1.125E-06    1.4873E-03  1.4864E-03  1.4771E-03  1.4370E-03  1.3272E-03  1.0086E-03  4.8225E-04  1.0983E-04  9.0431E-05
+ 1.125E-06 - 1.000E-06    1.0667E-03  1.0661E-03  1.0594E-03  1.0307E-03  9.5190E-04  7.2337E-04  3.4589E-04  7.8770E-05  6.4860E-05
+ 1.000E-06 - 8.000E-07    1.7027E-03  1.7016E-03  1.6910E-03  1.6451E-03  1.5194E-03  1.1546E-03  5.5209E-04  1.2573E-04  1.0353E-04
+ 8.000E-07 - 4.140E-07    3.2863E-03  3.2842E-03  3.2637E-03  3.1752E-03  2.9325E-03  2.2285E-03  1.0656E-03  2.4267E-04  1.9981E-04
+ 4.140E-07 - 3.250E-07    3.5766E-04  3.5751E-04  3.5552E-04  3.4665E-04  3.2213E-04  2.5094E-04  1.3335E-04  5.0138E-05  4.5803E-05
+ 3.250E-07 - 2.250E-07    5.0766E-05  5.0889E-05  5.1049E-05  5.1223E-05  5.1248E-05  5.1248E-05  5.1247E-05  5.1244E-05  5.1240E-05
+ 2.250E-07 - 1.000E-07    3.6344E-05  3.6432E-05  3.6546E-05  3.6671E-05  3.6689E-05  3.6689E-05  3.6688E-05  3.6685E-05  3.6683E-05
+ 1.000E-07 - 5.000E-08    1.0398E-08  1.0398E-08  1.0398E-08  1.0399E-08  1.0401E-08  1.0409E-08  1.0431E-08  1.0510E-08  1.0602E-08
+ 5.000E-08 - 3.000E-08    4.1577E-09  4.1577E-09  4.1578E-09  4.1581E-09  4.1589E-09  4.1620E-09  4.1708E-09  4.2024E-09  4.2394E-09
+ 3.000E-08 - 1.000E-08    3.2104E-09  3.2104E-09  3.2105E-09  3.2107E-09  3.2113E-09  3.2137E-09  3.2205E-09  3.2449E-09  3.2735E-09
+ 1.000E-08 - 1.000E-11    0.0000E+00  0.0000E+00  0.0000E+00  0.0000E+00  0.0000E+00  0.0000E+00  0.0000E+00  0.0000E+00  0.0000E+00
+  --------------------
+                 total    5.9033E+07  5.8996E+07  5.8634E+07  5.7086E+07  5.2865E+07  4.0624E+07  2.0415E+07  6.1886E+06  5.5366E+06
+=========================================================================================================================
+.
+.
+=========================================================================================================================
+=   spontaneous fission neutron source spectrum as a function of time for case '6' (#6/6)                               =
+=   Case 6 Decay #3 (5 years)                                                                                           =
+-------------------------------------------------------------------------------------------------------------------------
+     boundaries (MeV)      1700.0d     1701.0d     1703.0d     1710.0d     1730.0d     1800.0d     2000.0d     2700.0d     3525.0d   
+ 2.000E+01 - 6.376E+00    1.3040E+07  1.3045E+07  1.3005E+07  1.2831E+07  1.2356E+07  1.0969E+07  8.6182E+06  6.5691E+06  5.9559E+06
+ 6.376E+00 - 3.012E+00    1.2926E+08  1.2930E+08  1.2890E+08  1.2715E+08  1.2236E+08  1.0839E+08  8.4730E+07  6.4232E+07  5.8230E+07
+ 3.012E+00 - 1.827E+00    1.4834E+08  1.4839E+08  1.4793E+08  1.4590E+08  1.4038E+08  1.2426E+08  9.6969E+07  7.3375E+07  6.6520E+07
+ 1.827E+00 - 1.423E+00    7.0295E+07  7.0317E+07  7.0101E+07  6.9139E+07  6.6518E+07  5.8872E+07  4.5923E+07  3.4735E+07  3.1491E+07
+ 1.423E+00 - 9.072E-01    1.0123E+08  1.0126E+08  1.0095E+08  9.9566E+07  9.5791E+07  8.4777E+07  6.6126E+07  5.0013E+07  4.5343E+07
+ 9.072E-01 - 4.076E-01    9.8761E+07  9.8792E+07  9.8487E+07  9.7137E+07  9.3455E+07  8.2714E+07  6.4525E+07  4.8810E+07  4.4253E+07
+ 4.076E-01 - 1.111E-01    4.5367E+07  4.5382E+07  4.5242E+07  4.4622E+07  4.2932E+07  3.8003E+07  2.9654E+07  2.2439E+07  2.0345E+07
+ 1.111E-01 - 1.503E-02    7.9317E+06  7.9342E+06  7.9098E+06  7.8015E+06  7.5063E+06  6.6451E+06  5.1865E+06  3.9257E+06  3.5594E+06
+ 1.503E-02 - 3.035E-03    3.8911E+05  3.8923E+05  3.8804E+05  3.8273E+05  3.6825E+05  3.2601E+05  2.5448E+05  1.9263E+05  1.7466E+05
+ 3.035E-03 - 5.830E-04    3.5690E+04  3.5701E+04  3.5591E+04  3.5104E+04  3.3776E+04  2.9902E+04  2.3341E+04  1.7669E+04  1.6021E+04
+ 5.830E-04 - 1.013E-04    3.0446E+03  3.0455E+03  3.0362E+03  2.9946E+03  2.8813E+03  2.5509E+03  1.9912E+03  1.5073E+03  1.3667E+03
+ 1.013E-04 - 2.902E-05    2.0133E+02  2.0140E+02  2.0078E+02  1.9803E+02  1.9054E+02  1.6869E+02  1.3167E+02  9.9676E+01  9.0377E+01
+ 2.902E-05 - 1.068E-05    2.8332E+01  2.8341E+01  2.8253E+01  2.7867E+01  2.6813E+01  2.3737E+01  1.8529E+01  1.4026E+01  1.2718E+01
+ 1.068E-05 - 3.059E-06    6.8895E+00  6.8917E+00  6.8705E+00  6.7765E+00  6.5201E+00  5.7723E+00  4.5058E+00  3.4109E+00  3.0926E+00
+ 3.059E-06 - 1.855E-06    6.5843E-01  6.5864E-01  6.5661E-01  6.4762E-01  6.2313E-01  5.5166E-01  4.3062E-01  3.2597E-01  2.9556E-01
+ 1.855E-06 - 1.300E-06    2.4376E-01  2.4383E-01  2.4309E-01  2.3976E-01  2.3069E-01  2.0423E-01  1.5942E-01  1.2068E-01  1.0942E-01
+ 1.300E-06 - 1.125E-06    6.7293E-02  6.7314E-02  6.7108E-02  6.6189E-02  6.3686E-02  5.6381E-02  4.4010E-02  3.3316E-02  3.0207E-02
+ 1.125E-06 - 1.000E-06    4.5184E-02  4.5199E-02  4.5060E-02  4.4443E-02  4.2762E-02  3.7857E-02  2.9551E-02  2.2370E-02  2.0283E-02
+ 1.000E-06 - 8.000E-07    6.6349E-02  6.6370E-02  6.6166E-02  6.5260E-02  6.2792E-02  5.5590E-02  4.3393E-02  3.2848E-02  2.9783E-02
+ 8.000E-07 - 4.140E-07    1.0477E-01  1.0480E-01  1.0448E-01  1.0305E-01  9.9151E-02  8.7779E-02  6.8519E-02  5.1868E-02  4.7029E-02
+ 4.140E-07 - 3.250E-07    1.8914E-02  1.8920E-02  1.8862E-02  1.8604E-02  1.7900E-02  1.5847E-02  1.2370E-02  9.3640E-03  8.4904E-03
+ 3.250E-07 - 2.250E-07    1.8322E-02  1.8328E-02  1.8271E-02  1.8021E-02  1.7340E-02  1.5351E-02  1.1983E-02  9.0708E-03  8.2245E-03
+ 2.250E-07 - 1.000E-07    1.7518E-02  1.7523E-02  1.7469E-02  1.7230E-02  1.6579E-02  1.4677E-02  1.1457E-02  8.6727E-03  7.8635E-03
+ 1.000E-07 - 5.000E-08    4.7681E-03  4.7696E-03  4.7550E-03  4.6899E-03  4.5125E-03  3.9949E-03  3.1184E-03  2.3606E-03  2.1404E-03
+ 5.000E-08 - 3.000E-08    1.3958E-03  1.3962E-03  1.3919E-03  1.3729E-03  1.3209E-03  1.1694E-03  9.1283E-04  6.9100E-04  6.2653E-04
+ 3.000E-08 - 1.000E-08    9.7876E-04  9.7907E-04  9.7606E-04  9.6270E-04  9.2628E-04  8.2005E-04  6.4012E-04  4.8457E-04  4.3936E-04
+ 1.000E-08 - 1.000E-11    2.3323E-04  2.3330E-04  2.3258E-04  2.2940E-04  2.2072E-04  1.9541E-04  1.5254E-04  1.1548E-04  1.0471E-04
+  --------------------
+                 total    6.1465E+08  6.1484E+08  6.1295E+08  6.0456E+08  5.8170E+08  5.1499E+08  4.0201E+08  3.0431E+08  2.7589E+08
+=========================================================================================================================
+.
+.
+=========================================================================================================================
+=   delayed neutron source spectrum as a function of time for case '6' (#6/6)                                           =
+=   Case 6 Decay #3 (5 years)                                                                                           =
+-------------------------------------------------------------------------------------------------------------------------
+.
+   --- all entries are zero in this table ---
+.
+=========================================================================================================================
+.
+.
+=========================================================================================================================
+=   Total (a,n / SF / delayed) neutron source spectrum as a function of time for case '6' (#6/6)                        =
+=   Case 6 Decay #3 (5 years)                                                                                           =
+-------------------------------------------------------------------------------------------------------------------------
+                                   (neutron spectra for uranium dioxide matrix)
+     boundaries (MeV)      1700.0d     1701.0d     1703.0d     1710.0d     1730.0d     1800.0d     2000.0d     2700.0d     3525.0d   
+ 2.000E+01 - 6.376E+00    1.3040E+07  1.3045E+07  1.3005E+07  1.2831E+07  1.2356E+07  1.0969E+07  8.6182E+06  6.5691E+06  5.9559E+06
+ 6.376E+00 - 3.012E+00    1.4977E+08  1.4979E+08  1.4927E+08  1.4696E+08  1.4068E+08  1.2236E+08  9.1515E+07  6.5945E+07  5.9692E+07
+ 3.012E+00 - 1.827E+00    1.7290E+08  1.7293E+08  1.7233E+08  1.6967E+08  1.6242E+08  1.4129E+08  1.0572E+08  7.6312E+07  6.9208E+07
+ 1.827E+00 - 1.423E+00    7.5458E+07  7.5477E+07  7.5229E+07  7.4134E+07  7.1147E+07  6.2440E+07  4.7741E+07  3.5322E+07  3.2023E+07
+ 1.423E+00 - 9.072E-01    1.0545E+08  1.0548E+08  1.0514E+08  1.0364E+08  9.9568E+07  8.7682E+07  6.7591E+07  5.0465E+07  4.5748E+07
+ 9.072E-01 - 4.076E-01    1.0168E+08  1.0171E+08  1.0139E+08  9.9961E+07  9.6071E+07  8.4725E+07  6.5538E+07  4.9121E+07  4.4533E+07
+ 4.076E-01 - 1.111E-01    4.6758E+07  4.6771E+07  4.6623E+07  4.5967E+07  4.4179E+07  3.8963E+07  3.0142E+07  2.2594E+07  2.0485E+07
+ 1.111E-01 - 1.503E-02    8.1885E+06  8.1909E+06  8.1649E+06  8.0500E+06  7.7369E+06  6.8234E+06  5.2786E+06  3.9572E+06  3.5883E+06
+ 1.503E-02 - 3.035E-03    4.0038E+05  4.0049E+05  3.9923E+05  3.9363E+05  3.7837E+05  3.3386E+05  2.5859E+05  1.9412E+05  1.7604E+05
+ 3.035E-03 - 5.830E-04    3.6579E+04  3.6590E+04  3.6475E+04  3.5965E+04  3.4576E+04  3.0523E+04  2.3668E+04  1.7789E+04  1.6132E+04
+ 5.830E-04 - 1.013E-04    3.1338E+03  3.1347E+03  3.1248E+03  3.0809E+03  2.9614E+03  2.6126E+03  2.0228E+03  1.5179E+03  1.3764E+03
+ 1.013E-04 - 2.902E-05    2.0775E+02  2.0781E+02  2.0716E+02  2.0424E+02  1.9630E+02  1.7313E+02  1.3396E+02  1.0046E+02  9.1110E+01
+ 2.902E-05 - 1.068E-05    2.8669E+01  2.8678E+01  2.8589E+01  2.8193E+01  2.7116E+01  2.3973E+01  1.8652E+01  1.4068E+01  1.2753E+01
+ 1.068E-05 - 3.059E-06    6.9545E+00  6.9567E+00  6.9351E+00  6.8393E+00  6.5782E+00  5.8165E+00  4.5270E+00  3.4158E+00  3.0967E+00
+ 3.059E-06 - 1.855E-06    6.6868E-01  6.6888E-01  6.6679E-01  6.5753E-01  6.3228E-01  5.5861E-01  4.3395E-01  3.2674E-01  2.9619E-01
+ 1.855E-06 - 1.300E-06    2.4849E-01  2.4856E-01  2.4778E-01  2.4433E-01  2.3491E-01  2.0744E-01  1.6095E-01  1.2103E-01  1.0971E-01
+ 1.300E-06 - 1.125E-06    6.8781E-02  6.8801E-02  6.8585E-02  6.7626E-02  6.5013E-02  5.7390E-02  4.4493E-02  3.3425E-02  3.0298E-02
+ 1.125E-06 - 1.000E-06    4.6251E-02  4.6265E-02  4.6119E-02  4.5474E-02  4.3714E-02  3.8581E-02  2.9897E-02  2.2449E-02  2.0348E-02
+ 1.000E-06 - 8.000E-07    6.8051E-02  6.8071E-02  6.7857E-02  6.6905E-02  6.4311E-02  5.6744E-02  4.3945E-02  3.2974E-02  2.9887E-02
+ 8.000E-07 - 4.140E-07    1.0805E-01  1.0808E-01  1.0774E-01  1.0622E-01  1.0208E-01  9.0007E-02  6.9584E-02  5.2111E-02  4.7229E-02
+ 4.140E-07 - 3.250E-07    1.9272E-02  1.9278E-02  1.9217E-02  1.8950E-02  1.8222E-02  1.6098E-02  1.2503E-02  9.4142E-03  8.5362E-03
+ 3.250E-07 - 2.250E-07    1.8373E-02  1.8379E-02  1.8322E-02  1.8072E-02  1.7391E-02  1.5402E-02  1.2034E-02  9.1220E-03  8.2758E-03
+ 2.250E-07 - 1.000E-07    1.7554E-02  1.7560E-02  1.7506E-02  1.7267E-02  1.6615E-02  1.4714E-02  1.1493E-02  8.7093E-03  7.9002E-03
+ 1.000E-07 - 5.000E-08    4.7681E-03  4.7696E-03  4.7550E-03  4.6899E-03  4.5125E-03  3.9949E-03  3.1184E-03  2.3606E-03  2.1404E-03
+ 5.000E-08 - 3.000E-08    1.3958E-03  1.3962E-03  1.3919E-03  1.3729E-03  1.3209E-03  1.1694E-03  9.1283E-04  6.9100E-04  6.2654E-04
+ 3.000E-08 - 1.000E-08    9.7876E-04  9.7907E-04  9.7606E-04  9.6270E-04  9.2629E-04  8.2005E-04  6.4013E-04  4.8458E-04  4.3937E-04
+ 1.000E-08 - 1.000E-11    2.3323E-04  2.3330E-04  2.3258E-04  2.2940E-04  2.2072E-04  1.9541E-04  1.5254E-04  1.1548E-04  1.0471E-04
+  --------------------
+                 total    6.7368E+08  6.7384E+08  6.7159E+08  6.6165E+08  6.3457E+08  5.5562E+08  4.2243E+08  3.1050E+08  2.8143E+08
+=========================================================================================================================
+.
+.
+.
+.
+.
+.
+.
+.
+=========================================================================================================================
+ORIGEN finished successfully.
+=========================================================================================================================
+    module origen used 8.68 seconds cpu time for the current pass.
+
+    module origen is finished. completion code    0. total cpu time used 0 seconds.
+
+
+    SCALE is finished on Wed Jul 13 18:08:31 2016.
+-------------------------- Summary --------------------------
+shell finished. used 6.45 seconds.
+origen finished. used 8.68 seconds.
+SCALE driver required a maximum of 144 MiB of RAM.
+------------------------ End Summary ------------------------
+
+InterpLib.f33 copied to /home/nsly/cyclus/cyborg/tests/InterpLib.f33.

--- a/tests/tst_cyclus_origen_interface.cpp
+++ b/tests/tst_cyclus_origen_interface.cpp
@@ -27,22 +27,26 @@ protected:
      fluxes.push_back(2.e14);
      fluxes.push_back(3.e14);
 
+     // Powers in watts.
      powers.push_back(1.e7);
      powers.push_back(2.e7);
      powers.push_back(3.e7);
 
+     // Time assignments in days.
      times.push_back(0.);
      times.push_back(100.);
      times.push_back(200.);
-     times.push_back(300.);  
+     times.push_back(300.); 
 
      // Initial concentrations; default units of kg
      concs.push_back(4.0);
      concs.push_back(96.0);
 
+     // IDs can be either zzzaaai or pizzzaaa/sizzzaaa.
      ids.push_back(922350);
      ids.push_back(922380);
 
+     // Can specify libraries directly, or use library path.
      lib_names.push_back("ce14_e20.arplib");
      lib_names.push_back("ce14_e30.arplib");
 
@@ -170,8 +174,7 @@ TEST_F(OrigenInterfaceTester,parameterManipulation){
 }
 
 TEST_F(OrigenInterfaceTester,interpolationTest){
-  // Tests for failure, not correctness.
-  // No methods currently in place to test for correctness.
+  // Tests for failure, not correctness. Test for correctness in tst_interface_correctness.cpp.
 
   EXPECT_THROW(tester.interpolate(),cyclus::StateError);
 
@@ -185,7 +188,7 @@ TEST_F(OrigenInterfaceTester,interpolationTest){
   EXPECT_THROW(tester.interpolate(),cyclus::ValueError);
 
   tester.set_lib_path(lib_path);
-  std::cout << "Expect next line to be warning about unspecified tag 'Moderator Density'." << std::endl;
+  std::cout << "Expect next line to be warning about unspecified tag 'Moderator Density'.\n";
   EXPECT_NO_THROW(tester.interpolate());
 }
 
@@ -207,6 +210,9 @@ TEST_F(OrigenInterfaceTester,materialTest){
   iblank.push_back(1);
   EXPECT_THROW(tester.set_materials(iblank,concs),cyclus::ValueError);
 
+  tester.set_powers(powers);
+  tester.set_time_steps(times);
+
   EXPECT_NO_THROW(tester.set_materials(ids,concs));
 }
 /* Commented out until such time as fluxes are properly implemented.
@@ -214,6 +220,9 @@ TEST_F(OrigenInterfaceTester,materialTest){
 ** interpolate the Origen library over burnup to get transition
 ** structure data at the appropriate burnups, which is the only way
 ** to get a relevant conversion from flux to power/burnup.
+** 
+** Followup: Probably not that hard as it may be built into one of
+** The ORIGEN objects.  Currently neglected out of ambivalance.
 TEST_F(OrigenInterfaceTester,fluxTest){
   EXPECT_THROW(tester.set_fluxes(dblank),cyclus::StateError);
   tester.set_fluxes(fluxes);
@@ -235,20 +244,20 @@ TEST_F(OrigenInterfaceTester,solveTest){
   tester.set_parameters(params);
   tester.set_lib_path(lib_path);
   tester.interpolate();
-  tester.set_materials(ids,concs);
-  EXPECT_THROW(tester.solve(),cyclus::StateError);
+  EXPECT_THROW(tester.set_materials(ids,concs),cyclus::ValueError);
 
   tester.set_powers(powers);
-  EXPECT_THROW(tester.solve(),cyclus::ValueError);
+  EXPECT_THROW(tester.set_materials(ids,concs),cyclus::ValueError);
   tester.delete_powers();
 
   dblank.push_back(1.);
   tester.set_time_steps(times);
   tester.set_powers(dblank);
-  EXPECT_THROW(tester.solve(),cyclus::ValueError);
+  EXPECT_THROW(tester.set_materials(ids,concs),cyclus::ValueError);
   tester.delete_powers();
 
   tester.set_powers(powers);
+  tester.set_materials(ids,concs);
   ASSERT_NO_THROW(tester.solve());
 
   // Check burnups for each step
@@ -284,10 +293,10 @@ TEST_F(OrigenInterfaceTester,resultTest){
   tester.set_lib_path(lib_path);
   tester.interpolate();
 
-  tester.set_materials(ids,concs);
   tester.set_powers(powers);
   tester.set_time_steps(times); 
   ASSERT_TRUE(powers.size() == times.size()-1);
+  tester.set_materials(ids,concs);
 
   ASSERT_NO_THROW(tester.solve());
 
@@ -320,204 +329,3 @@ TEST_F(OrigenInterfaceTester,resultTest){
     EXPECT_EQ(mass_out[i],masses_out[numTimes-1][i]) << "Disagreement between return of get_masses() and get_masses_final().";
   }
 }
-/*
-
-int main(int argc, char ** argv){
-  OrigenInterface::cyclus2origen tester;
-// Library names should be specified as string literals.  Names can
-// be given as absolute or relative pathnames if the library is not
-// in the current directory.
-
-  tester.set_lib_names({"ce14_e20.arplib","ce14_e30.arplib","ce14_e40.arplib"});
-
-  tester.list_lib_names();
-  std::cout << std::endl;
-
-  tester.remove_lib_names({"ce14_e40.arplib","ce14_e30.arplib"});
-
-  tester.list_lib_names();
-  std::cout << std::endl;
-
-  tester.add_lib_names({"ce14_e30.arplib"});
-
-  tester.list_lib_names();
-  std::cout << std::endl;
-
-  tester.remove_lib_names({"ce14_e30.arplib","ce14_e20.arplib"});
-
-  tester.set_lib_path("/home/nsly/scale_dev_data/arplibs");
-  tester.list_lib_names();
-  std::cout << std::endl;
-
-// Setting the ID tags are done one-by-one giving the name and
-// value of the ID tags as string literals.  These will be used
-// to collect the appropriate libraries from the ones provided,
-// allowing the list of libraries to actually include more than
-// those actually used for this calculation.  This does require
-// that the libraries have the tags set.  This can be checked
-// using the obiwan tool included with Origen.
-//
-// usage -- obiwan tag [library name]
-
-  tester.set_id_tag("Assembly Type","ce14x14");
-  tester.set_id_tag("Fuel Type","Uranium");
-  tester.set_id_tag("Not real","Fake");
-
-  tester.list_id_tags();
-  std::cout << std::endl;
-
-  tester.remove_id_tag("Not real");
-  tester.remove_id_tag("Fuel Type");
-
-  tester.list_id_tags();
-  std::cout << std::endl;
-
-  tester.set_id_tag("Fuel Type","Uranium");
-
-  tester.list_id_tags();
-  std::cout << std::endl;
-
-  tester.remove_id_tag("Assembly Type");
-  tester.remove_id_tag("Fuel Type");
-
-  std::map<std::string,std::string> id_tags;
-
-  id_tags["Assembly Type"] = "ce14x14";
-  id_tags["Fuel Type"] = "Uranium";
-
-  tester.set_id_tags(id_tags);
-
-  tester.list_id_tags();
-  std::cout << std::endl;
-
-// Adding the parameters adds the interpolable tags to the Tag
-// Manager on the cyclus2origen object (here: tester).  These
-// will be used by the interpolate function to interpolate
-// between the libraries set in set_lib_names that match the
-// ID tags set in set_id_tags to generate a single library that
-// will be used in the set_materials function.  This allows for
-// the use of problem-specific libraries that may not precisely
-// match those already on-disk.
-
-  tester.add_parameter("Enrichment",2.5);
-  tester.add_parameter("Fuel Temp",9000);
-
-  tester.list_parameters();
-  std::cout << std::endl;
-
-  tester.remove_parameter("Fuel Temp");
-
-  tester.list_parameters();
-  std::cout << std::endl;
-
-  tester.remove_parameter("Enrichment");
-
-  std::map<std::string,double> interp_tags;
-
-  interp_tags["Enrichment"] = 2.5;
-  interp_tags["Fuel Temp"] = 9000.;
-
-  tester.set_parameters(interp_tags);
-
-  tester.list_parameters();
-  std::cout << std::endl;
-
-  tester.remove_parameter("Fuel Temp");
-
-  tester.list_parameters();
-  std::cout << std::endl;
-
-// Interpolation using the aforementioned libraries and tags.
-// This will generate a single library at the user-defined
-// point in the parameter space.  This library's cross sections
-// will be used as the basis for the depletion calculation.
-
-  std::cout << "Expect warning about undefined interp value:" << std::endl;
-  tester.interpolate();
-
-// Setting the volume of the material in the problem.
-
-//  tester.set_volume(3);
-
-// Setting the vector of nuclide IDs using the sizzzaaa format.
-// Will allow for alternative formats in the future.
-
-  std::vector<int> ids;
-  ids.push_back(20092235);
-  ids.push_back(20092238);
-
-// Setting the number densities of the isotopes specified in
-// the ids vector.  The position of the densities in this
-// vector should directly correspond with the isotope vector.
-
-  std::vector<double> numden;
-  numden.push_back(5);
-  numden.push_back(95);
-
-// Uses the library generated by interpolate and the volume
-// along with the IDs and number densities provided in the
-// input parameters to create the Material object used to
-// simulate the depletion calculation.
-
-  tester.set_materials(ids,numden);
-
-// Specifying the fluxes to be used in the depletion
-// calculation.  There should be a flux for each burn step.
-
-//  std::vector<double> fluxes(3,1.0e14);
-//  tester.set_flux(fluxes);
-
-  std::vector<double> powers(4,200);
-  tester.set_powers(powers);
-
-// Specifying the times for which isotopics will be kept.
-// Should have one more element than the fluxes, as the
-// burn steps will occur between the times specified here.
-// Units are specified in their own call using strings
-// to spell out the units (i.e. "seconds", "days","years").
-// This unit will apply to the entire times vector.
-
-  std::vector<double> times(4,0.0);
-  times[1] = 200;
-  times[2] = 500;
-  times[3] = 5000;
-  tester.set_time_steps(times);
-  tester.set_time_units("seconds");
-
-// Calling the solver to calculate the isotopics after
-// every depletion step.
-
-  tester.solve();
-
-// Getting the concentration vectors and printing the number
-// of vectors received.  Should be equal to the size of the times vector.
-
-  std::vector<std::vector<double>> concs_vecs;
-  tester.get_concentrations(concs_vecs);
-  std::cout << "Total concentration vectors calculated: " << concs_vecs.size() << " == " << times.size() << " times." << std::endl;
-
-// Getting the concentrations after the first burn step
-// and printing the size of the vector (number of concentrations.)
-
-  std::vector<double> concs;
-  tester.get_concentrations_at(1,concs);
-  std::cout << "Concentration set 2 has size: " << concs.size() << "." << std::endl;
-
-// Getting the concentrations after the first burn step
-// and printing the size of the vector (number of concentrations.)
-
-  std::vector<double> concs_final;
-  tester.get_concentrations_final(concs_final);
-  std::cout << "Last concentration set has size: " << concs_final.size() << "." << std::endl;
-
-// Getting the nuclide ids (sizzzaaa format) for the entire
-// problem and printing the size of the vector.  Should equal
-// the number of concentrations at any step.
-
-  std::vector<int> id_out;
-  tester.get_ids(id_out);
-  std::cout << "ID vector has size: " << id_out.size() << "." << std::endl;
-
-  return 0;
-}
-*/

--- a/tests/tst_interface_correctness.cpp
+++ b/tests/tst_interface_correctness.cpp
@@ -1,0 +1,264 @@
+/*!
+ *  \file - tst_interface_correctness.cpp
+ *  \author - Nicholas C. Sly, Steven E. Skutnik
+ */
+
+#include <algorithm>
+#include <iostream>
+#include <vector>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "cyclus_origen_interface.h"
+#include "orglib_default_location.h"
+#include "error.h"
+#include "Origen/Core/dc/ConcentrationConverter.h"
+#include "Origen/Core/dc/ConcentrationUnit.h"
+#include "Origen/Core/dc/FakeFactory.h"
+#include "Origen/Core/dc/Library.h"
+#include "Origen/Core/dc/TagManager.h"
+
+using namespace OrigenInterface;
+
+// iso: isotope (generally zzzaaa) and val: value in GATOMS.
+double unitConv(int iso, double val)
+{
+  auto conv = Origen::ConcentrationConverter();
+  conv.convert_to(Origen::ConcentrationUnit::KILOGRAMS,iso,Origen::ConcentrationUnit::GATOMS,val);
+  return val;
+}
+
+class OrigenResultTester : public ::testing::Test {
+protected:
+
+  OrigenResultTester() {
+  } 
+
+  void SetUp() {
+      // Setting the path to the libraries
+      lib_path = ORIGEN_LIBS_DEFAULT;
+
+      // Setting ID tags for w17x17 assembly
+      id_tags["Assembly Type"] = "w17x17";
+
+      // Setting Interp tags for enrichment
+      interp_tags["Enrichment"] = 2.7;
+
+      // Setting material IDS
+      ids.push_back(922340);
+      ids.push_back(922350);
+      ids.push_back(922360);
+      ids.push_back(922380);
+
+      // Setting material initial concentrations in kg
+      concs.push_back(0.534); // for u-234
+      concs.push_back(27.); // for u-235
+      concs.push_back(0.276); // for u-236
+      concs.push_back(972.19); // for u-238
+
+      // Setting powers and breaks in Watts.
+      powers.push_back(20.e6);
+      powers.push_back(20.e6);
+      powers.push_back(20.e6);
+      powers.push_back(20.e6);
+      powers.push_back(20.e6);
+      powers.push_back(20.e6);
+      powers.push_back(20.e6);
+      powers.push_back(20.e6);
+      powers.push_back(20.e6);
+      powers.push_back(20.e6);
+      powers.push_back(0.);
+      powers.push_back(0.);
+      powers.push_back(0.);
+      powers.push_back(0.);
+      powers.push_back(0.);
+      powers.push_back(0.);
+      powers.push_back(0.);
+      powers.push_back(0.);
+      powers.push_back(0.);
+      powers.push_back(19.e6);
+      powers.push_back(19.e6);
+      powers.push_back(19.e6);
+      powers.push_back(19.e6);
+      powers.push_back(19.e6);
+      powers.push_back(19.e6);
+      powers.push_back(19.e6);
+      powers.push_back(19.e6);
+      powers.push_back(19.e6);
+      powers.push_back(19.e6);
+      powers.push_back(0.);
+      powers.push_back(0.);
+      powers.push_back(0.);
+      powers.push_back(0.);
+      powers.push_back(0.);
+      powers.push_back(0.);
+      powers.push_back(0.);
+      powers.push_back(0.);
+      powers.push_back(0.);
+      powers.push_back(18.e6);
+      powers.push_back(18.e6);
+      powers.push_back(18.e6);
+      powers.push_back(18.e6);
+      powers.push_back(18.e6);
+      powers.push_back(18.e6);
+      powers.push_back(18.e6);
+      powers.push_back(18.e6);
+      powers.push_back(18.e6);
+      powers.push_back(18.e6);
+      powers.push_back(0.);
+      powers.push_back(0.);
+      powers.push_back(0.);
+      powers.push_back(0.);
+      powers.push_back(0.);
+      powers.push_back(0.);
+      powers.push_back(0.);
+      powers.push_back(0.);
+
+      //  Setting times (must be cumulative).. in days
+      times.push_back(0.);
+      times.push_back(54.);
+      times.push_back(108.);
+      times.push_back(162.);
+      times.push_back(216.);
+      times.push_back(270.);
+      times.push_back(324.);
+      times.push_back(378.);
+      times.push_back(432.);
+      times.push_back(486.);
+      times.push_back(540.);
+      times.push_back(540.01);
+      times.push_back(540.03);
+      times.push_back(540.1);
+      times.push_back(540.3);
+      times.push_back(541.);
+      times.push_back(543.);
+      times.push_back(550.);
+      times.push_back(570.);
+      times.push_back(580.);
+      times.push_back(634.);
+      times.push_back(688.);
+      times.push_back(742.);
+      times.push_back(796.);
+      times.push_back(850.);
+      times.push_back(904.);
+      times.push_back(958.);
+      times.push_back(1012.);
+      times.push_back(1066.);
+      times.push_back(1120.);
+      times.push_back(1120.01);
+      times.push_back(1120.03);
+      times.push_back(1120.1);
+      times.push_back(1120.3);
+      times.push_back(1121.);
+      times.push_back(1123.);
+      times.push_back(1130.);
+      times.push_back(1150.);
+      times.push_back(1160.);
+      times.push_back(1214.);
+      times.push_back(1268.);
+      times.push_back(1322.);
+      times.push_back(1376.);
+      times.push_back(1430.);
+      times.push_back(1484.);
+      times.push_back(1538.);
+      times.push_back(1592.);
+      times.push_back(1646.);
+      times.push_back(1700.);
+      times.push_back(1701.);
+      times.push_back(1703.);
+      times.push_back(1710.);
+      times.push_back(1730.);
+      times.push_back(1800.);
+      times.push_back(2000.);
+      times.push_back(2700.);
+      times.push_back(3525.);
+  }
+
+  void TearDown() {    
+  }
+
+  std::string lib_path;
+  std::map<std::string,std::string> id_tags;
+  std::map<std::string,double> interp_tags;
+  std::vector<int> ids;
+  std::vector<double> powers, times, concs;
+  cyclus2origen tester;
+};
+
+
+TEST_F(OrigenResultTester,CorrectnessTest){
+  tester.set_lib_path(lib_path); 
+  tester.set_id_tags(id_tags);
+  tester.set_parameters(interp_tags);
+  EXPECT_NO_THROW(tester.interpolate());
+  tester.set_powers(powers);
+  tester.set_time_steps(times);
+  EXPECT_NO_THROW(tester.set_materials(ids,concs));
+  EXPECT_NO_THROW(tester.solve());
+
+  std::map<int,double> masses_out;
+
+  tester.get_masses_at_easy(0,masses_out);
+
+  double test234 = 0.534;
+
+  auto tmp234 = masses_out[922340];
+
+  EXPECT_NEAR(tmp234,test234,0.001) << "Initial mass for u-234 does not match previous external calculation results.";
+
+  // Value 445.7490 grams comes from an externally executed combination of obiwan and origen depletion.
+  test234 = 0.445749;
+
+  masses_out.clear();
+  tester.get_masses_at_easy(10,masses_out);
+
+  tmp234 = masses_out[922340];
+
+  EXPECT_NEAR(tmp234,test234,0.001) << "Mass of u-234 after initial burn does not match previous external calculation results.";
+
+  test234 = 0.3710746;
+
+  masses_out.clear();
+  tester.get_masses_at_easy(29,masses_out);
+
+  tmp234 = masses_out[922340];
+
+  EXPECT_NEAR(tmp234,test234,0.001) << "Mass of u-234 after second burn does not match previous external calculation results.";
+
+  test234 = 0.3711255;
+
+  masses_out.clear();
+  tester.get_masses_at_easy(38,masses_out);
+
+  tmp234 = masses_out[922340];
+
+  EXPECT_NEAR(tmp234,test234,0.001) << "Mass of u-234 after second decay does not match previous external calculation results.";
+
+  test234 = 0.3085457;
+
+  masses_out.clear();
+  tester.get_masses_at_easy(48,masses_out);
+
+  tmp234 = masses_out[922340];
+
+  EXPECT_NEAR(tmp234,test234,0.001) << "Mass of u-234 after final burn does not match previous external calculation results.";
+
+  test234 = 0.3146113;
+
+  masses_out.clear();
+  tester.get_masses_at_easy(56,masses_out);
+
+  tmp234 = masses_out[922340];
+
+  EXPECT_NEAR(tmp234,test234,0.001) << "Mass of u-234 after final burn does not match previous external calculation results.";
+
+  test234 = 0.3146113;
+
+  masses_out.clear();
+  tester.get_masses_final_easy(masses_out);
+
+  tmp234 = masses_out[922340];
+
+  EXPECT_NEAR(tmp234,test234,0.001) << "Resulting mass for u-234 does not match previous external calculation results.";
+}


### PR DESCRIPTION
…to get correct answer (set powers and times before materials).  

Also includes updated version to use concurrency exploiting collectLibrariesParallel function in {scale}/packages/Origen/Core/fn/io.h to improve speed of collecting libraries from disk.  

Added "easy" functions for getting material information results after solve to give data in std::map<int,double> format with the lookup being the isotope number and the value being the mass in the desired units.

Many lines were touched as I also changed all std::endl to '\n' for faster execution.  Not really a big impact as most or all output is in exceptions.

Finally, general code cleanup and commenting for clarity.